### PR TITLE
Add PyTorch version of SSD-MobileNet-V1

### DIFF
--- a/edge/object_detection/ssd_mobilenet_v1/pytorch/README.md
+++ b/edge/object_detection/ssd_mobilenet_v1/pytorch/README.md
@@ -1,0 +1,140 @@
+# SSD-MobileNet-v1 in PyTorch
+
+This repo implements SSD-MobileNet-v1 in inference mode in PyTorch.
+It uses the pre-trained weight files from [the TensorFlow Object Detection ModelZoo](http://download.tensorflow.org/models/object_detection/ssd_mobilenet_v1_coco_2018_01_28.tar.gz).
+
+## Installation instructions
+
+### Requirements
+- PyTorch 1.0 or later
+- torchvision
+- cocoapi
+- TensorFlow 1.12 (for loading the weights)
+
+### Step-by-step installation with conda
+
+```bash
+# first, make sure that your conda is setup properly with the right environment
+# for that, check that `which conda`, `which pip` and `which python` points to the
+# right path. From a clean conda env, this is what you need to do
+
+conda create --name pytorch_ssd_mobilenet
+conda activate pytorch_ssd_mobilenet
+
+# this installs the right pip and dependencies for the fresh python
+conda install ipython
+
+# follow PyTorch installation in https://pytorch.org/get-started/locally/
+# we give the instructions for CUDA 9.0
+conda install -c pytorch pytorch torchvision cudatoolkit=9.0
+
+# install pycocotools
+cd github
+git clone https://github.com/cocodataset/cocoapi.git
+cd cocoapi/PythonAPI
+python setup.py build_ext install
+
+# install TF for decoding the weights
+pip install tensorflow
+```
+
+## Running it
+
+First, download the pre-trained weights from the TensorFlow ModelZoo
+```bash
+curl http://download.tensorflow.org/models/object_detection/ssd_mobilenet_v1_coco_2018_01_28.tar.gz -o ssd_mobilenet_v1_coco_2018_01_28.tar.gz
+
+tar -zxvf ssd_mobilenet_v1_coco_2018_01_28.tar.gz
+```
+
+Now that you have dowloaded the weights, you can perform inference it via
+```bash
+python test_on_coco.py \
+    --dataset-root /path/to/coco/imgs \
+    --ann-file /path/to/coco/ann_file \
+    --imgs-to-evaluate 50 \
+    --weights-file ssd_mobilenet_v1_coco_2018_01_28/frozen_inference_graph.pb
+```
+which should give as a result
+```
+2019-03-20 11:34:36.297500: I tensorflow/core/platform/cpu_feature_guard.cc:141] Your CPU supports instructions that this TensorFlow binary was not compiled to use: AVX2 FMA
+2019-03-20 11:34:36.325873: I tensorflow/core/platform/profile_utils/cpu_utils.cc:94] CPU Frequency: 2199815000 Hz
+2019-03-20 11:34:36.330036: I tensorflow/compiler/xla/service/service.cc:150] XLA service 0x5590161a41b0 executing computations on platform Host. Devices:
+2019-03-20 11:34:36.330057: I tensorflow/compiler/xla/service/service.cc:158]   StreamExecutor device (0): <undefined>, <undefined>
+loading annotations into memory...
+Done (t=0.50s)
+creating index...
+index created!
+Loading and preparing results...
+DONE (t=0.00s)
+creating index...
+index created!
+Running per image evaluation...
+Evaluate annotation type *bbox*
+DONE (t=0.18s).
+Accumulating evaluation results...
+DONE (t=0.18s).
+ Average Precision  (AP) @[ IoU=0.50:0.95 | area=   all | maxDets=100 ] = 0.316
+ Average Precision  (AP) @[ IoU=0.50      | area=   all | maxDets=100 ] = 0.444
+ Average Precision  (AP) @[ IoU=0.75      | area=   all | maxDets=100 ] = 0.357
+ Average Precision  (AP) @[ IoU=0.50:0.95 | area= small | maxDets=100 ] = 0.062
+ Average Precision  (AP) @[ IoU=0.50:0.95 | area=medium | maxDets=100 ] = 0.177
+ Average Precision  (AP) @[ IoU=0.50:0.95 | area= large | maxDets=100 ] = 0.691
+ Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets=  1 ] = 0.294
+ Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets= 10 ] = 0.324
+ Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets=100 ] = 0.324
+ Average Recall     (AR) @[ IoU=0.50:0.95 | area= small | maxDets=100 ] = 0.062
+ Average Recall     (AR) @[ IoU=0.50:0.95 | area=medium | maxDets=100 ] = 0.178
+ Average Recall     (AR) @[ IoU=0.50:0.95 | area= large | maxDets=100 ] = 0.709
+Summary:
+-------------------------------
+Setup time 7.618103981018066s
+All images loaded in 0.5562152862548828s
+All images detected in 1.1915736198425293s
+Average detection time: 0.024317828976378148s
+mAP: 0.3159874092405704
+Recall: 0.2940712479080072
+-------------------------------
+```
+
+Here are the results when evaluating on the full 5000 images of COCO val2017
+```
+2019-03-20 11:26:00.922253: I tensorflow/core/platform/cpu_feature_guard.cc:141] Your CPU supports instructions that this TensorFlow binary was not compiled to use: AVX2 FMA
+2019-03-20 11:26:00.949812: I tensorflow/core/platform/profile_utils/cpu_utils.cc:94] CPU Frequency: 2199815000 Hz
+2019-03-20 11:26:00.954376: I tensorflow/compiler/xla/service/service.cc:150] XLA service 0x55ad827e71b0 executing computations on platform Host. Devices:
+2019-03-20 11:26:00.954409: I tensorflow/compiler/xla/service/service.cc:158]   StreamExecutor device (0): <undefined>, <undefined>
+loading annotations into memory...
+Done (t=0.49s)
+creating index...
+index created!
+Loading and preparing results...
+DONE (t=0.21s)
+creating index...
+index created!
+Running per image evaluation...
+Evaluate annotation type *bbox*
+DONE (t=10.37s).
+Accumulating evaluation results...
+DONE (t=1.93s).
+ Average Precision  (AP) @[ IoU=0.50:0.95 | area=   all | maxDets=100 ] = 0.205
+ Average Precision  (AP) @[ IoU=0.50      | area=   all | maxDets=100 ] = 0.317
+ Average Precision  (AP) @[ IoU=0.75      | area=   all | maxDets=100 ] = 0.226
+ Average Precision  (AP) @[ IoU=0.50:0.95 | area= small | maxDets=100 ] = 0.015
+ Average Precision  (AP) @[ IoU=0.50:0.95 | area=medium | maxDets=100 ] = 0.144
+ Average Precision  (AP) @[ IoU=0.50:0.95 | area= large | maxDets=100 ] = 0.483
+ Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets=  1 ] = 0.192
+ Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets= 10 ] = 0.240
+ Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets=100 ] = 0.240
+ Average Recall     (AR) @[ IoU=0.50:0.95 | area= small | maxDets=100 ] = 0.018
+ Average Recall     (AR) @[ IoU=0.50:0.95 | area=medium | maxDets=100 ] = 0.160
+ Average Recall     (AR) @[ IoU=0.50:0.95 | area= large | maxDets=100 ] = 0.569
+Summary:
+-------------------------------
+Setup time 8.944006204605103s
+All images loaded in 49.411635398864746s
+All images detected in 90.85995388031006s
+Average detection time: 0.01817562590124226s
+mAP: 0.20468113436884472
+Recall: 0.1923766276941554
+-------------------------------
+```

--- a/edge/object_detection/ssd_mobilenet_v1/pytorch/anchor_generator.py
+++ b/edge/object_detection/ssd_mobilenet_v1/pytorch/anchor_generator.py
@@ -1,0 +1,394 @@
+import torch
+import numpy as np
+
+
+# The following functions were taken from 
+# https://github.com/tensorflow/models/tree/master/research/object_detection
+# with minor modifications so that they use
+# torch operations instead
+
+def expanded_shape(orig_shape, start_dim, num_dims):
+    s = (1,) * num_dims
+    return orig_shape[:start_dim] + s + orig_shape[start_dim:]
+
+
+def meshgrid(x, y):
+    """Tiles the contents of x and y into a pair of grids.
+    Multidimensional analog of numpy.meshgrid, giving the same behavior if x and y
+    are vectors. Generally, this will give:
+    xgrid(i1, ..., i_m, j_1, ..., j_n) = x(j_1, ..., j_n)
+    ygrid(i1, ..., i_m, j_1, ..., j_n) = y(i_1, ..., i_m)
+    Keep in mind that the order of the arguments and outputs is reverse relative
+    to the order of the indices they go into, done for compatibility with numpy.
+    The output tensors have the same shapes.  Specifically:
+    xgrid.get_shape() = y.get_shape().concatenate(x.get_shape())
+    ygrid.get_shape() = y.get_shape().concatenate(x.get_shape())
+    Args:
+    x: A tensor of arbitrary shape and rank. xgrid will contain these values
+       varying in its last dimensions.
+    y: A tensor of arbitrary shape and rank. ygrid will contain these values
+       varying in its first dimensions.
+    Returns:
+    A tuple of tensors (xgrid, ygrid).
+    """
+    x = torch.as_tensor(x)
+    y = torch.as_tensor(y)
+    x_exp_shape = expanded_shape(x.shape, 0, y.dim())
+    y_exp_shape = expanded_shape(y.shape, y.dim(), x.dim())
+
+    xgrid = torch.reshape(x, x_exp_shape).repeat(*y_exp_shape)
+    ygrid = torch.reshape(y, y_exp_shape).repeat(*x_exp_shape)
+    new_shape = y.shape + x.shape
+    xgrid = xgrid.reshape(new_shape)
+    ygrid = ygrid.reshape(new_shape)
+
+    return xgrid, ygrid
+
+
+def tile_anchors(grid_height,
+                 grid_width,
+                 scales,
+                 aspect_ratios,
+                 base_anchor_size,
+                 anchor_stride,
+                 anchor_offset):
+  """Create a tiled set of anchors strided along a grid in image space.
+  This op creates a set of anchor boxes by placing a "basis" collection of
+  boxes with user-specified scales and aspect ratios centered at evenly
+  distributed points along a grid.  The basis collection is specified via the
+  scale and aspect_ratios arguments.  For example, setting scales=[.1, .2, .2]
+  and aspect ratios = [2,2,1/2] means that we create three boxes: one with scale
+  .1, aspect ratio 2, one with scale .2, aspect ratio 2, and one with scale .2
+  and aspect ratio 1/2.  Each box is multiplied by "base_anchor_size" before
+  placing it over its respective center.
+  Grid points are specified via grid_height, grid_width parameters as well as
+  the anchor_stride and anchor_offset parameters.
+  Args:
+    grid_height: size of the grid in the y direction (int or int scalar tensor)
+    grid_width: size of the grid in the x direction (int or int scalar tensor)
+    scales: a 1-d  (float) tensor representing the scale of each box in the
+      basis set.
+    aspect_ratios: a 1-d (float) tensor representing the aspect ratio of each
+      box in the basis set.  The length of the scales and aspect_ratios tensors
+      must be equal.
+    base_anchor_size: base anchor size as [height, width]
+      (float tensor of shape [2])
+    anchor_stride: difference in centers between base anchors for adjacent grid
+                   positions (float tensor of shape [2])
+    anchor_offset: center of the anchor with scale and aspect ratio 1 for the
+                   upper left element of the grid, this should be zero for
+                   feature networks with only VALID padding and even receptive
+                   field size, but may need some additional calculation if other
+                   padding is used (float tensor of shape [2])
+  Returns:
+    a BoxList holding a collection of N anchor boxes
+  """
+  aspect_ratios = torch.as_tensor(aspect_ratios, dtype=torch.float32)
+  scales = torch.as_tensor(scales, dtype=torch.float32)
+
+  ratio_sqrts = torch.sqrt(aspect_ratios)
+  heights = scales / ratio_sqrts * base_anchor_size[0]
+  widths = scales * ratio_sqrts * base_anchor_size[1]
+
+  # Get a grid of box centers
+  y_centers = torch.arange(grid_height, dtype=torch.float32)
+  y_centers = y_centers * anchor_stride[0] + anchor_offset[0]
+  x_centers = torch.arange(grid_width, dtype=torch.float32)
+  x_centers = x_centers * anchor_stride[1] + anchor_offset[1]
+
+  x_centers, y_centers = meshgrid(x_centers, y_centers)
+
+  widths_grid, x_centers_grid = meshgrid(widths, x_centers)
+  heights_grid, y_centers_grid = meshgrid(heights, y_centers)
+
+  bbox_centers = torch.stack([y_centers_grid, x_centers_grid], dim=3)
+  bbox_sizes = torch.stack([heights_grid, widths_grid], dim=3)
+  bbox_centers = torch.reshape(bbox_centers, [-1, 2])
+  bbox_sizes = torch.reshape(bbox_sizes, [-1, 2])
+  bbox_corners = _center_size_bbox_to_corners_bbox(bbox_centers, bbox_sizes)
+  return bbox_corners
+
+
+def _center_size_bbox_to_corners_bbox(centers, sizes):
+  """Converts bbox center-size representation to corners representation.
+  Args:
+    centers: a tensor with shape [N, 2] representing bounding box centers
+    sizes: a tensor with shape [N, 2] representing bounding boxes
+  Returns:
+    corners: tensor with shape [N, 4] representing bounding boxes in corners
+      representation
+  """
+  return torch.cat([centers - .5 * sizes, centers + .5 * sizes], 1)
+
+
+def create_ssd_anchors(num_layers=6,
+                       min_scale=0.2,
+                       max_scale=0.95,
+                       scales=None,
+                       aspect_ratios=(1.0, 2.0, 1.0 / 2, 3.0, 1.0 / 3),
+                       interpolated_scale_aspect_ratio=1.0,
+                       base_anchor_size=None,
+                       anchor_strides=None,
+                       anchor_offsets=None,
+                       reduce_boxes_in_lowest_layer=True):
+  """Creates MultipleGridAnchorGenerator for SSD anchors.
+  This function instantiates a MultipleGridAnchorGenerator that reproduces
+  ``default box`` construction proposed by Liu et al in the SSD paper.
+  See Section 2.2 for details. Grid sizes are assumed to be passed in
+  at generation time from finest resolution to coarsest resolution --- this is
+  used to (linearly) interpolate scales of anchor boxes corresponding to the
+  intermediate grid sizes.
+  Anchors that are returned by calling the `generate` method on the returned
+  MultipleGridAnchorGenerator object are always in normalized coordinates
+  and clipped to the unit square: (i.e. all coordinates lie in [0, 1]x[0, 1]).
+  Args:
+    num_layers: integer number of grid layers to create anchors for (actual
+      grid sizes passed in at generation time)
+    min_scale: scale of anchors corresponding to finest resolution (float)
+    max_scale: scale of anchors corresponding to coarsest resolution (float)
+    scales: As list of anchor scales to use. When not None and not empty,
+      min_scale and max_scale are not used.
+    aspect_ratios: list or tuple of (float) aspect ratios to place on each
+      grid point.
+    interpolated_scale_aspect_ratio: An additional anchor is added with this
+      aspect ratio and a scale interpolated between the scale for a layer
+      and the scale for the next layer (1.0 for the last layer).
+      This anchor is not included if this value is 0.
+    base_anchor_size: base anchor size as [height, width].
+      The height and width values are normalized to the minimum dimension of the
+      input height and width, so that when the base anchor height equals the
+      base anchor width, the resulting anchor is square even if the input image
+      is not square.
+    anchor_strides: list of pairs of strides in pixels (in y and x directions
+      respectively). For example, setting anchor_strides=[(25, 25), (50, 50)]
+      means that we want the anchors corresponding to the first layer to be
+      strided by 25 pixels and those in the second layer to be strided by 50
+      pixels in both y and x directions. If anchor_strides=None, they are set to
+      be the reciprocal of the corresponding feature map shapes.
+    anchor_offsets: list of pairs of offsets in pixels (in y and x directions
+      respectively). The offset specifies where we want the center of the
+      (0, 0)-th anchor to lie for each layer. For example, setting
+      anchor_offsets=[(10, 10), (20, 20)]) means that we want the
+      (0, 0)-th anchor of the first layer to lie at (10, 10) in pixel space
+      and likewise that we want the (0, 0)-th anchor of the second layer to lie
+      at (25, 25) in pixel space. If anchor_offsets=None, then they are set to
+      be half of the corresponding anchor stride.
+    reduce_boxes_in_lowest_layer: a boolean to indicate whether the fixed 3
+      boxes per location is used in the lowest layer.
+  Returns:
+    a MultipleGridAnchorGenerator
+  """
+  if base_anchor_size is None:
+    base_anchor_size = [1.0, 1.0]
+  base_anchor_size = torch.tensor(base_anchor_size, dtype=torch.float32)
+  box_specs_list = []
+  if scales is None or not scales:
+    scales = [min_scale + (max_scale - min_scale) * i / (num_layers - 1)
+              for i in range(num_layers)] + [1.0]
+  else:
+    # Add 1.0 to the end, which will only be used in scale_next below and used
+    # for computing an interpolated scale for the largest scale in the list.
+    scales += [1.0]
+
+  for layer, scale, scale_next in zip(
+      range(num_layers), scales[:-1], scales[1:]):
+    layer_box_specs = []
+    if layer == 0 and reduce_boxes_in_lowest_layer:
+      layer_box_specs = [(0.1, 1.0), (scale, 2.0), (scale, 0.5)]
+    else:
+      for aspect_ratio in aspect_ratios:
+        layer_box_specs.append((scale, aspect_ratio))
+      # Add one more anchor, with a scale between the current scale, and the
+      # scale for the next layer, with a specified aspect ratio (1.0 by
+      # default).
+      if interpolated_scale_aspect_ratio > 0.0:
+        layer_box_specs.append((np.sqrt(scale*scale_next),
+                                interpolated_scale_aspect_ratio))
+    box_specs_list.append(layer_box_specs)
+
+  return MultipleGridAnchorGenerator(box_specs_list, base_anchor_size,
+                                     anchor_strides, anchor_offsets)
+
+class MultipleGridAnchorGenerator(object):
+  """Generate a grid of anchors for multiple CNN layers."""
+
+  def __init__(self,
+               box_specs_list,
+               base_anchor_size=None,
+               anchor_strides=None,
+               anchor_offsets=None,
+               clip_window=None):
+    """Constructs a MultipleGridAnchorGenerator.
+    To construct anchors, at multiple grid resolutions, one must provide a
+    list of feature_map_shape_list (e.g., [(8, 8), (4, 4)]), and for each grid
+    size, a corresponding list of (scale, aspect ratio) box specifications.
+    For example:
+    box_specs_list = [[(.1, 1.0), (.1, 2.0)],  # for 8x8 grid
+                      [(.2, 1.0), (.3, 1.0), (.2, 2.0)]]  # for 4x4 grid
+    To support the fully convolutional setting, we pass grid sizes in at
+    generation time, while scale and aspect ratios are fixed at construction
+    time.
+    Args:
+      box_specs_list: list of list of (scale, aspect ratio) pairs with the
+        outside list having the same number of entries as feature_map_shape_list
+        (which is passed in at generation time).
+      base_anchor_size: base anchor size as [height, width]
+                        (length-2 float tensor, default=[1.0, 1.0]).
+                        The height and width values are normalized to the
+                        minimum dimension of the input height and width, so that
+                        when the base anchor height equals the base anchor
+                        width, the resulting anchor is square even if the input
+                        image is not square.
+      anchor_strides: list of pairs of strides in pixels (in y and x directions
+        respectively). For example, setting anchor_strides=[(25, 25), (50, 50)]
+        means that we want the anchors corresponding to the first layer to be
+        strided by 25 pixels and those in the second layer to be strided by 50
+        pixels in both y and x directions. If anchor_strides=None, they are set
+        to be the reciprocal of the corresponding feature map shapes.
+      anchor_offsets: list of pairs of offsets in pixels (in y and x directions
+        respectively). The offset specifies where we want the center of the
+        (0, 0)-th anchor to lie for each layer. For example, setting
+        anchor_offsets=[(10, 10), (20, 20)]) means that we want the
+        (0, 0)-th anchor of the first layer to lie at (10, 10) in pixel space
+        and likewise that we want the (0, 0)-th anchor of the second layer to
+        lie at (25, 25) in pixel space. If anchor_offsets=None, then they are
+        set to be half of the corresponding anchor stride.
+      clip_window: a tensor of shape [4] specifying a window to which all
+        anchors should be clipped. If clip_window is None, then no clipping
+        is performed.
+    Raises:
+      ValueError: if box_specs_list is not a list of list of pairs
+      ValueError: if clip_window is not either None or a tensor of shape [4]
+    """
+    if isinstance(box_specs_list, list) and all(
+        [isinstance(list_item, list) for list_item in box_specs_list]):
+      self._box_specs = box_specs_list
+    else:
+      raise ValueError('box_specs_list is expected to be a '
+                       'list of lists of pairs')
+    if base_anchor_size is None:
+      base_anchor_size = torch.tensor([256, 256], dtype=torch.float32)
+    self._base_anchor_size = base_anchor_size
+    self._anchor_strides = anchor_strides
+    self._anchor_offsets = anchor_offsets
+    if clip_window is not None and list(clip_window.shape) != [4]:
+      raise ValueError('clip_window must either be None or a shape [4] tensor')
+    self._clip_window = clip_window
+    self._scales = []
+    self._aspect_ratios = []
+    for box_spec in self._box_specs:
+      if not all([isinstance(entry, tuple) and len(entry) == 2
+                  for entry in box_spec]):
+        raise ValueError('box_specs_list is expected to be a '
+                         'list of lists of pairs')
+      scales, aspect_ratios = zip(*box_spec)
+      self._scales.append(scales)
+      self._aspect_ratios.append(aspect_ratios)
+
+    for arg, arg_name in zip([self._anchor_strides, self._anchor_offsets],
+                             ['anchor_strides', 'anchor_offsets']):
+      if arg and not (isinstance(arg, list) and
+                      len(arg) == len(self._box_specs)):
+        raise ValueError('%s must be a list with the same length '
+                         'as self._box_specs' % arg_name)
+      if arg and not all([
+          isinstance(list_item, tuple) and len(list_item) == 2
+          for list_item in arg
+      ]):
+        raise ValueError('%s must be a list of pairs.' % arg_name)
+
+
+  def _generate(self, feature_map_shape_list, im_height=1, im_width=1):
+    """Generates a collection of bounding boxes to be used as anchors.
+    The number of anchors generated for a single grid with shape MxM where we
+    place k boxes over each grid center is k*M^2 and thus the total number of
+    anchors is the sum over all grids. In our box_specs_list example
+    (see the constructor docstring), we would place two boxes over each grid
+    point on an 8x8 grid and three boxes over each grid point on a 4x4 grid and
+    thus end up with 2*8^2 + 3*4^2 = 176 anchors in total. The layout of the
+    output anchors follows the order of how the grid sizes and box_specs are
+    specified (with box_spec index varying the fastest, followed by width
+    index, then height index, then grid index).
+    Args:
+      feature_map_shape_list: list of pairs of convnet layer resolutions in the
+        format [(height_0, width_0), (height_1, width_1), ...]. For example,
+        setting feature_map_shape_list=[(8, 8), (7, 7)] asks for anchors that
+        correspond to an 8x8 layer followed by a 7x7 layer.
+      im_height: the height of the image to generate the grid for. If both
+        im_height and im_width are 1, the generated anchors default to
+        absolute coordinates, otherwise normalized coordinates are produced.
+      im_width: the width of the image to generate the grid for. If both
+        im_height and im_width are 1, the generated anchors default to
+        absolute coordinates, otherwise normalized coordinates are produced.
+    Returns:
+      boxes_list: a list of BoxLists each holding anchor boxes corresponding to
+        the input feature map shapes.
+    Raises:
+      ValueError: if feature_map_shape_list, box_specs_list do not have the same
+        length.
+      ValueError: if feature_map_shape_list does not consist of pairs of
+        integers
+    """
+    if not (isinstance(feature_map_shape_list, list)
+            and len(feature_map_shape_list) == len(self._box_specs)):
+      raise ValueError('feature_map_shape_list must be a list with the same '
+                       'length as self._box_specs')
+    if not all([isinstance(list_item, tuple) and len(list_item) == 2
+                for list_item in feature_map_shape_list]):
+      raise ValueError('feature_map_shape_list must be a list of pairs.')
+
+    im_height = float(im_height)
+    im_width = float(im_width)
+
+    if not self._anchor_strides:
+      anchor_strides = [(1.0 / float(pair[0]), 1.0 / float(pair[1]))
+                        for pair in feature_map_shape_list]
+    else:
+      anchor_strides = [(float(stride[0]) / im_height,
+                         float(stride[1]) / im_width)
+                        for stride in self._anchor_strides]
+    if not self._anchor_offsets:
+      anchor_offsets = [(0.5 * stride[0], 0.5 * stride[1])
+                        for stride in anchor_strides]
+    else:
+      anchor_offsets = [(float(offset[0]) / im_height,
+                         float(offset[1]) / im_width)
+                        for offset in self._anchor_offsets]
+
+    for arg, arg_name in zip([anchor_strides, anchor_offsets],
+                             ['anchor_strides', 'anchor_offsets']):
+      if not (isinstance(arg, list) and len(arg) == len(self._box_specs)):
+        raise ValueError('%s must be a list with the same length '
+                         'as self._box_specs' % arg_name)
+      if not all([isinstance(list_item, tuple) and len(list_item) == 2
+                  for list_item in arg]):
+        raise ValueError('%s must be a list of pairs.' % arg_name)
+
+    anchor_grid_list = []
+    min_im_shape = min(im_height, im_width)
+    scale_height = min_im_shape / im_height
+    scale_width = min_im_shape / im_width
+    base_anchor_size = [
+        scale_height * self._base_anchor_size[0],
+        scale_width * self._base_anchor_size[1]
+    ]
+    for feature_map_index, (grid_size, scales, aspect_ratios, stride,
+                            offset) in enumerate(
+                                zip(feature_map_shape_list, self._scales,
+                                    self._aspect_ratios, anchor_strides,
+                                    anchor_offsets)):
+      tiled_anchors = tile_anchors(
+          grid_height=grid_size[0],
+          grid_width=grid_size[1],
+          scales=scales,
+          aspect_ratios=aspect_ratios,
+          base_anchor_size=base_anchor_size,
+          anchor_stride=stride,
+          anchor_offset=offset)
+      if self._clip_window is not None:
+        raise NotImplementedError("Oups!")
+      num_anchors_in_layer = len(tiled_anchors)
+      anchor_indices = feature_map_index * torch.ones(num_anchors_in_layer)
+      anchor_grid_list.append(tiled_anchors)
+
+    return anchor_grid_list

--- a/edge/object_detection/ssd_mobilenet_v1/pytorch/convert_tf_weights.py
+++ b/edge/object_detection/ssd_mobilenet_v1/pytorch/convert_tf_weights.py
@@ -1,0 +1,137 @@
+import torch
+
+import re
+from collections import OrderedDict
+
+
+def remap_tf_base_names(orig_weights):
+    prefix = "backbone."
+
+    # convs
+    weights = {
+        k: v for k, v in orig_weights.items() if "FeatureExtractor/MobilenetV1" in k
+    }
+    convs = {
+        k: v
+        for k, v in weights.items()
+        if "batchnorm" not in k and "pointwise_" not in k
+    }
+
+    matcher = re.compile("(.*)Conv2d_(\d+)")
+    mapping = {}
+    for k in convs.keys():
+        l = matcher.match(k).group(2)
+        name = "pointwise" if "pointwise" in k else "depthwise"
+        if l == "0":
+            name = "0"
+        mapping[k] = "{}{}.{}.weight".format(prefix, l, name)
+
+    # batch norm
+    weights = {
+        k: v
+        for k, v in orig_weights.items()
+        if "FeatureExtractor/MobilenetV1/MobilenetV1" in k
+    }
+    weights = {k: v for k, v in weights.items() if "pointwise_" not in k}
+    for k in weights.keys():
+        l = matcher.match(k).group(2)
+        name = "pointwise" if "pointwise" in k else "depthwise"
+        op = "scale" if "mul" in k else "bias"
+        if l == "0":
+            name = "0"
+        mapping[k] = "{}{}.{}/BatchNorm.{}".format(prefix, l, name, op)
+
+    return mapping
+
+
+def remap_tf_extras(orig_weights):
+    prefix = "extras."
+
+    weights = {
+        k: v for k, v in orig_weights.items() if "FeatureExtractor/MobilenetV1" in k
+    }
+    weights = {k: v for k, v in weights.items() if "pointwise_" in k}
+
+    matcher = re.compile("(.*)Conv2d_(\d+)_(\d)x(\d)")
+    mapping = {}
+    for k in weights.keys():
+        m = matcher.match(k)
+        l = int(m.group(2)) - 2
+        ks = int(m.group(3))
+        if ks == 1:
+            pos = 0
+        else:
+            pos = 2
+        wtype = "weight" if "weight" in k else "bias"
+        mapping[k] = "{}{}.{}.{}".format(prefix, l, pos, wtype)
+
+    return mapping
+
+
+def remap_tf_predictors(orig_weights):
+    mapping = {}
+
+    # regression
+    weights = {k: v for k, v in orig_weights.items() if "BoxPredictor" in k}
+    weights = {k: v for k, v in weights.items() if "BoxEncodingPredictor" in k}
+
+    matcher = re.compile("BoxPredictor_(\d+)")
+    for k in weights.keys():
+        pos = matcher.match(k).group(1)
+        wtype = "weight" if "weights" in k else "bias"
+        mapping[k] = "predictors.{}.regression.{}".format(pos, wtype)
+
+    # classification
+    weights = {k: v for k, v in orig_weights.items() if "BoxPredictor" in k}
+    weights = {k: v for k, v in weights.items() if "ClassPredictor" in k}
+
+    for k in weights.keys():
+        pos = matcher.match(k).group(1)
+        wtype = "weight" if "weights" in k else "bias"
+        mapping[k] = "predictors.{}.classification.{}".format(pos, wtype)
+
+    return mapping
+
+
+def remap_tf_names(weights):
+    layers_base = remap_tf_base_names(weights)
+    layers_extra = remap_tf_extras(weights)
+    layers_predictors = remap_tf_predictors(weights)
+
+    layers = {}
+    layers.update(layers_base)
+    layers.update(layers_extra)
+    layers.update(layers_predictors)
+
+    return layers
+
+
+def get_state_dict(weights):
+    layers = remap_tf_names(weights)
+    state_dict = OrderedDict()
+
+    for orig, new in layers.items():
+        weight = weights[orig]
+        weight = torch.as_tensor(weight, dtype=torch.float32)
+        if weight.dim() == 4:
+            p = (2, 3, 0, 1)
+            if "pointwise" in orig or "backbone.0." in new or "BoxPredictor" in orig:
+                p = (3, 2, 0, 1)
+            weight = weight.permute(*p).contiguous()
+        state_dict[new] = weight
+    return state_dict
+
+
+def read_tf_weights(frozen_model):
+    import tensorflow as tf
+    from tensorflow.python.framework import tensor_util
+    weights = {}
+    with tf.Session() as sess:
+        with tf.gfile.GFile(frozen_model, 'rb') as f:
+            graph_def = tf.GraphDef()
+            graph_def.ParseFromString(f.read())
+            tf.import_graph_def(graph_def)
+        for n in graph_def.node:
+            if n.op == 'Const':
+                weights[n.name] = tensor_util.MakeNdarray(n.attr['value'].tensor)
+    return weights

--- a/edge/object_detection/ssd_mobilenet_v1/pytorch/ssd_mobilenet_v1.py
+++ b/edge/object_detection/ssd_mobilenet_v1/pytorch/ssd_mobilenet_v1.py
@@ -1,0 +1,254 @@
+from collections import OrderedDict
+
+import torch
+from torch import nn
+from torch.nn import functional as F
+
+from anchor_generator import create_ssd_anchors
+from utils import Conv2d_tf
+from utils import BatchNorm2d
+from utils import BiasAdd
+from utils import nms
+from utils import decode_boxes
+
+
+def conv_bn(inp, oup, stride):
+    return nn.Sequential(
+        OrderedDict(
+            [
+                ("0", Conv2d_tf(inp, oup, 3, stride, padding="SAME", bias=False)),
+                ("0/BatchNorm", BiasAdd(oup)),
+                ("0/ReLU", nn.ReLU6(inplace=True)),
+            ]
+        )
+    )
+
+
+def conv_dw(inp, oup, stride):
+    return nn.Sequential(
+        OrderedDict(
+            [
+                (
+                    "depthwise",
+                    Conv2d_tf(
+                        inp, inp, 3, stride, padding="SAME", groups=inp, bias=False
+                    ),
+                ),
+                ("depthwise/BatchNorm", BatchNorm2d(inp)),
+                ("depthwise/ReLU", nn.ReLU6(inplace=True)),
+                ("pointwise", nn.Conv2d(inp, oup, 1, 1, 0, bias=False)),
+                ("pointwise/BatchNorm", BiasAdd(oup)),
+                ("pointwise/ReLU", nn.ReLU6(inplace=True)),
+            ]
+        )
+    )
+
+
+class MobileNetV1Base(nn.ModuleList):
+    def __init__(self, return_layers=[11, 13]):
+        super(MobileNetV1Base, self).__init__(
+            [
+                conv_bn(3, 32, 2),
+                conv_dw(32, 64, 1),
+                conv_dw(64, 128, 2),
+                conv_dw(128, 128, 1),
+                conv_dw(128, 256, 2),
+                conv_dw(256, 256, 1),
+                conv_dw(256, 512, 2),
+                conv_dw(512, 512, 1),
+                conv_dw(512, 512, 1),
+                conv_dw(512, 512, 1),
+                conv_dw(512, 512, 1),
+                conv_dw(512, 512, 1),
+                conv_dw(512, 1024, 2),
+                conv_dw(1024, 1024, 1),
+            ]
+        )
+        self.return_layers = return_layers
+
+    def forward(self, x):
+        out = []
+        for idx, module in enumerate(self):
+            x = module(x)
+            if idx in self.return_layers:
+                out.append(x)
+        return out
+
+
+class PredictionHead(nn.Module):
+    def __init__(self, in_channels, num_classes, num_anchors):
+        super(PredictionHead, self).__init__()
+        self.classification = nn.Conv2d(
+            in_channels, num_classes * num_anchors, kernel_size=1
+        )
+        self.regression = nn.Conv2d(in_channels, num_anchors * 4, kernel_size=1)
+
+        self.num_classes = num_classes
+        self.num_anchors = num_anchors
+
+    def forward(self, x):
+        bs = x.shape[0]
+        class_logits = self.classification(x)
+        box_regression = self.regression(x)
+
+        class_logits = class_logits.permute(0, 2, 3, 1).reshape(
+            bs, -1, self.num_classes
+        )
+        box_regression = box_regression.permute(0, 2, 3, 1).reshape(bs, -1, 4)
+
+        return class_logits, box_regression
+
+
+class Block(nn.Sequential):
+    def __init__(self, in_channels, mid_channels, out_channels):
+        super(Block, self).__init__(
+            nn.Conv2d(in_channels, out_channels=mid_channels, kernel_size=1),
+            nn.ReLU(),
+            Conv2d_tf(
+                mid_channels, out_channels, kernel_size=3, stride=2, padding="SAME"
+            ),
+            nn.ReLU(),
+        )
+
+
+class SSD(nn.Module):
+    def __init__(self, backbone, predictors, extras):
+        super(SSD, self).__init__()
+
+        self.backbone = backbone
+        self.extras = extras
+        self.predictors = predictors
+
+        # preprocess
+        self.image_size = 300
+        self.image_mean = 127.5
+        self.image_std = 127.5
+
+        self.coder_weights = torch.tensor((10, 10, 5, 5), dtype=torch.float32)
+        self._feature_map_shapes = None
+
+        # postprocess
+        self.nms_threshold = 0.6
+
+        # set it to 0.01 for better results but slower runtime
+        self.score_threshold = 0.3
+
+    def forward(self, x):
+        feature_maps = self.backbone(x)
+
+        out = feature_maps[-1]
+        for module in self.extras:
+            out = module(out)
+            feature_maps.append(out)
+
+        results = []
+        for feature, module in zip(feature_maps, self.predictors):
+            results.append(module(feature))
+
+        class_logits, box_regression = list(zip(*results))
+        class_logits = torch.cat(class_logits, 1)
+        box_regression = torch.cat(box_regression, 1)
+
+        scores = F.softmax(class_logits, dim=2)
+        box_regression = box_regression.squeeze(0)
+
+        shapes = [o.shape[-2:] for o in feature_maps]
+        if shapes != self._feature_map_shapes:
+            # generate anchors for the sizes of the feature map
+            priors = create_ssd_anchors()._generate(shapes)
+            priors = torch.cat(priors, dim=0)
+            self.priors = priors.to(scores)
+            self._feature_map_shapes = shapes
+
+        self.coder_weights = self.coder_weights.to(scores)
+
+        boxes = decode_boxes(box_regression, self.priors, self.coder_weights)
+        # add a batch dimension
+        boxes = boxes[None]
+        return scores, boxes
+
+    def preprocess(self, image):
+        size = (self.image_size, self.image_size)
+        image = F.interpolate(image, size=size, mode="bilinear", align_corners=False)
+        image = (image - self.image_mean) / self.image_std
+        return image
+
+    def predict(self, images):
+        """
+        Arguments:
+            images (torch.Tensor[N,C,H,W]):
+        """
+        height, width = images.shape[-2:]
+        images = self.preprocess(images)
+        scores, boxes = self(images)
+        boxes, labels, scores = self.filter_results(scores, boxes)
+        boxes = self.rescale_boxes(boxes, height, width)
+        return boxes, labels, scores
+
+    def filter_results(self, scores, boxes):
+        # in order to avoid custom C++ extensions
+        # we use an NMS implementation written purely
+        # on python. This implementation is faster on the
+        # CPU, which is why we run this part on the CPU
+        cpu_device = torch.device("cpu")
+        boxes = boxes[0]
+        scores = scores[0]
+        boxes = boxes.to(cpu_device)
+        scores = scores.to(cpu_device)
+        selected_box_probs = []
+        labels = []
+        for class_index in range(1, scores.size(1)):
+            probs = scores[:, class_index]
+            mask = probs > self.score_threshold
+            probs = probs[mask]
+            subset_boxes = boxes[mask, :]
+            box_probs = torch.cat([subset_boxes, probs.reshape(-1, 1)], dim=1)
+            box_probs = nms(box_probs, self.nms_threshold)
+            selected_box_probs.append(box_probs)
+            labels.append(
+                torch.full((box_probs.size(0),), class_index, dtype=torch.int64)
+            )
+        selected_box_probs = torch.cat(selected_box_probs)
+        labels = torch.cat(labels)
+        return selected_box_probs[:, :4], labels, selected_box_probs[:, 4]
+
+    def rescale_boxes(self, boxes, height, width):
+        boxes[:, 0] *= width
+        boxes[:, 1] *= height
+        boxes[:, 2] *= width
+        boxes[:, 3] *= height
+        return boxes
+
+
+def create_mobilenetv1_ssd(num_classes):
+    backbone = MobileNetV1Base()
+
+    extras = nn.ModuleList(
+        [
+            Block(1024, 256, 512),
+            Block(512, 128, 256),
+            Block(256, 128, 256),
+            Block(256, 64, 128),
+        ]
+    )
+
+    predictors = nn.ModuleList(
+        [
+            PredictionHead(in_channels, num_classes, num_anchors)
+            for in_channels, num_anchors in zip(
+                (512, 1024, 512, 256, 256, 128), (3, 6, 6, 6, 6, 6)
+            )
+        ]
+    )
+
+    return SSD(backbone, predictors, extras)
+
+
+def get_tf_pretrained_mobilenet_ssd(weights_file):
+    from convert_tf_weights import get_state_dict, read_tf_weights
+
+    model = create_mobilenetv1_ssd(91)
+    weights = read_tf_weights(weights_file)
+    state_dict = get_state_dict(weights)
+    model.load_state_dict(state_dict)
+    return model

--- a/edge/object_detection/ssd_mobilenet_v1/pytorch/test_on_coco.py
+++ b/edge/object_detection/ssd_mobilenet_v1/pytorch/test_on_coco.py
@@ -1,0 +1,149 @@
+# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+import argparse
+import json
+import time
+import tempfile
+
+import torch
+import torchvision
+import numpy as np
+
+from pycocotools.coco import COCO
+from pycocotools.cocoeval import COCOeval
+
+from ssd_mobilenet_v1 import get_tf_pretrained_mobilenet_ssd
+
+
+def pil_to_tensor(image):
+    x = np.asarray(image).astype(np.float32)
+    x = torch.as_tensor(x).permute(2, 0, 1)
+    return x
+
+
+def evaluate_predictions_on_coco(
+    coco_gt, coco_results, json_result_file, imgs_to_evaluate
+):
+
+    with open(json_result_file, "w") as f:
+        json.dump(coco_results, f)
+
+    coco_dt = coco_gt.loadRes(str(json_result_file)) if coco_results else COCO()
+
+    coco_eval = COCOeval(coco_gt, coco_dt, "bbox")
+    coco_eval.params.imgIds = coco_eval.params.imgIds[:imgs_to_evaluate]
+    coco_eval.evaluate()
+    coco_eval.accumulate()
+    coco_eval.summarize()
+    return coco_eval
+
+
+def main():
+    parser = argparse.ArgumentParser(description="PyTorch Object Detection Inference")
+    parser.add_argument(
+        "--dataset-root",
+        default="datasets/coco/val2014",
+        metavar="PATH",
+        help="path to COCO image folder",
+    )
+    parser.add_argument(
+        "--ann-file",
+        default="datasets/coco/annotations/instances_minival2014.json",
+        metavar="PATH",
+        help="path to COCO annotation file",
+    )
+    parser.add_argument(
+        "--device", default="cuda", help="torch.device to use for inference [cpu, cuda]"
+    )
+    parser.add_argument(
+        "--imgs-to-evaluate", default=50, type=int, help="number of images to evaluate"
+    )
+    parser.add_argument(
+        "--weights-file",
+        default="ssd_mobilenet_v1_coco_2018_01_28/frozen_inference_graph.pb",
+        help="path to pre-trained weights",
+    )
+
+    args = parser.parse_args()
+
+    setup_time_begin = time.time()
+    device = torch.device(args.device)
+
+    model = get_tf_pretrained_mobilenet_ssd(args.weights_file)
+    model.eval()
+    model.to(device)
+
+    dataset = torchvision.datasets.CocoDetection(args.dataset_root, args.ann_file)
+    # for reproducibility
+    dataset.ids = sorted(dataset.ids)
+
+    setup_time = time.time() - setup_time_begin
+
+    results = []
+    test_time_begin = time.time()
+    load_time_total = 0
+    detect_time_total = 0
+    images_processed = 0
+    for idx in range(args.imgs_to_evaluate):
+        # Load image
+        load_time_begin = time.time()
+        image, _ = dataset[idx]
+        image = pil_to_tensor(image)[None]
+        load_time = time.time() - load_time_begin
+        load_time_total += load_time
+
+        # Detect image
+        detect_time_begin = time.time()
+        image = image.to(device)
+        with torch.no_grad():
+            boxes, labels, scores = model.predict(image)
+        if device.type == "cuda":
+            torch.cuda.synchronize()
+        detect_time = time.time() - detect_time_begin
+
+        # Exclude first image from averaging
+        if idx > 0 or args.imgs_to_evaluate == 1:
+            detect_time_total += detect_time
+            images_processed += 1
+
+        # convert predictions from xyxy to xywh
+        boxes[:, 2:] -= boxes[:, :2]
+
+        boxes = boxes.tolist()
+        scores = scores.tolist()
+        labels = labels.tolist()
+
+        results.extend(
+            [
+                {
+                    "image_id": dataset.ids[idx],
+                    "category_id": labels[k],
+                    "bbox": box,
+                    "score": scores[k],
+                }
+                for k, box in enumerate(boxes)
+            ]
+        )
+
+    test_time = time.time() - test_time_begin
+    detect_avg_time = detect_time_total / images_processed
+    load_avg_time = load_time_total / args.imgs_to_evaluate
+
+    with tempfile.NamedTemporaryFile() as f:
+        file_path = f.name
+        res = evaluate_predictions_on_coco(
+            dataset.coco, results, file_path, args.imgs_to_evaluate
+        )
+
+    print("Summary:")
+    print("-------------------------------")
+    print("Setup time {}s".format(setup_time))
+    print("All images loaded in {}s".format(load_time_total))
+    print("All images detected in {}s".format(detect_time_total))
+    print("Average detection time: {}s".format(detect_avg_time))
+    print("mAP: {}".format(res.stats[0]))
+    print("Recall: {}".format(res.stats[6]))
+    print("-------------------------------")
+
+
+if __name__ == "__main__":
+    main()

--- a/edge/object_detection/ssd_mobilenet_v1/pytorch/utils.py
+++ b/edge/object_detection/ssd_mobilenet_v1/pytorch/utils.py
@@ -1,0 +1,193 @@
+import torch
+import math
+
+from torch import nn
+from torch.nn import functional as F
+
+
+class BatchNorm2d(torch.jit.ScriptModule):
+    """
+    Fixed version of BatchNorm2d, which has only the scale and bias
+    """
+
+    def __init__(self, out):
+        super(BatchNorm2d, self).__init__()
+        self.register_buffer("scale", torch.ones(out))
+        self.register_buffer("bias", torch.zeros(out))
+
+    @torch.jit.script_method
+    def forward(self, x):
+        scale = self.scale.view(1, -1, 1, 1)
+        bias = self.bias.view(1, -1, 1, 1)
+        return x * scale + bias
+
+
+class BiasAdd(torch.jit.ScriptModule):
+    """
+    Fixed version of BatchNorm2d, which has only the scale and bias
+    """
+
+    def __init__(self, out):
+        super(BiasAdd, self).__init__()
+        self.register_buffer("bias", torch.zeros(out))
+
+    @torch.jit.script_method
+    def forward(self, x):
+        bias = self.bias.view(1, -1, 1, 1)
+        return x + bias
+
+
+class Conv2d_tf(nn.Conv2d):
+    """
+    Conv2d with the padding behavior from TF
+    """
+
+    def __init__(self, *args, **kwargs):
+        super(Conv2d_tf, self).__init__(*args, **kwargs)
+        self.padding = kwargs.get("padding", "SAME")
+
+    def _compute_padding(self, input, dim):
+        input_size = input.size(dim + 2)
+        filter_size = self.weight.size(dim + 2)
+        effective_filter_size = (filter_size - 1) * self.dilation[dim] + 1
+        out_size = (input_size + self.stride[dim] - 1) // self.stride[dim]
+        total_padding = max(
+            0, (out_size - 1) * self.stride[dim] + effective_filter_size - input_size
+        )
+        additional_padding = int(total_padding % 2 != 0)
+
+        return additional_padding, total_padding
+
+    def forward(self, input):
+        if self.padding == "VALID":
+            return F.conv2d(
+                input,
+                self.weight,
+                self.bias,
+                self.stride,
+                padding=0,
+                dilation=self.dilation,
+                groups=self.groups,
+            )
+        rows_odd, padding_rows = self._compute_padding(input, dim=0)
+        cols_odd, padding_cols = self._compute_padding(input, dim=1)
+        if rows_odd or cols_odd:
+            input = F.pad(input, [0, cols_odd, 0, rows_odd])
+
+        return F.conv2d(
+            input,
+            self.weight,
+            self.bias,
+            self.stride,
+            padding=(padding_rows // 2, padding_cols // 2),
+            dilation=self.dilation,
+            groups=self.groups,
+        )
+
+
+def box_area(left_top, right_bottom):
+    """Compute the areas of rectangles given two corners.
+
+    Args:
+        left_top (N, 2): left top corner.
+        right_bottom (N, 2): right bottom corner.
+
+    Returns:
+        area (N): return the area.
+    """
+    hw = torch.clamp(right_bottom - left_top, min=0.0)
+    return hw[..., 0] * hw[..., 1]
+
+
+def box_iou(boxes0, boxes1, eps=1e-5):
+    """Return intersection-over-union (Jaccard index) of boxes.
+
+    Args:
+        boxes0 (N, 4): ground truth boxes.
+        boxes1 (N or 1, 4): predicted boxes.
+        eps: a small number to avoid 0 as denominator.
+    Returns:
+        iou (N): IoU values.
+    """
+    overlap_left_top = torch.max(boxes0[..., :2], boxes1[..., :2])
+    overlap_right_bottom = torch.min(boxes0[..., 2:], boxes1[..., 2:])
+
+    overlap_area = box_area(overlap_left_top, overlap_right_bottom)
+    area0 = box_area(boxes0[..., :2], boxes0[..., 2:])
+    area1 = box_area(boxes1[..., :2], boxes1[..., 2:])
+    return overlap_area / (area0 + area1 - overlap_area + eps)
+
+
+def nms(box_scores, iou_threshold):
+    """
+
+    Args:
+        box_scores (N, 5): boxes in corner-form and probabilities.
+        iou_threshold: intersection over union threshold.
+    Returns:
+         picked: a list of indexes of the kept boxes
+    """
+    scores = box_scores[:, -1]
+    boxes = box_scores[:, :-1]
+    picked = []
+    _, indexes = scores.sort(descending=True)
+    while len(indexes) > 0:
+        current = indexes[0]
+        picked.append(current.item())
+        if len(indexes) == 1:
+            break
+        current_box = boxes[current, :]
+        indexes = indexes[1:]
+        rest_boxes = boxes[indexes, :]
+        iou = box_iou(rest_boxes, current_box.unsqueeze(0))
+        indexes = indexes[iou <= iou_threshold]
+
+    return box_scores[picked, :]
+
+
+@torch.jit.script
+def decode_boxes(rel_codes, boxes, weights):
+    # type: (torch.Tensor, torch.Tensor, torch.Tensor) -> torch.Tensor
+
+    # perform some unpacking to make it JIT-fusion friendly
+    wx = weights[1]
+    wy = weights[0]
+    ww = weights[3]
+    wh = weights[2]
+
+    boxes_x1 = boxes[:, 1].unsqueeze(1)
+    boxes_y1 = boxes[:, 0].unsqueeze(1)
+    boxes_x2 = boxes[:, 3].unsqueeze(1)
+    boxes_y2 = boxes[:, 2].unsqueeze(1)
+
+    dx = rel_codes[:, 1].unsqueeze(1)
+    dy = rel_codes[:, 0].unsqueeze(1)
+    dw = rel_codes[:, 3].unsqueeze(1)
+    dh = rel_codes[:, 2].unsqueeze(1)
+
+    # implementation starts here
+    widths = boxes_x2 - boxes_x1
+    heights = boxes_y2 - boxes_y1
+    ctr_x = boxes_x1 + 0.5 * widths
+    ctr_y = boxes_y1 + 0.5 * heights
+
+    dx = dx / wx
+    dy = dy / wy
+    dw = dw / ww
+    dh = dh / wh
+
+    pred_ctr_x = dx * widths + ctr_x
+    pred_ctr_y = dy * heights + ctr_y
+    pred_w = torch.exp(dw) * widths
+    pred_h = torch.exp(dh) * heights
+
+    pred_boxes = torch.cat(
+        [
+            pred_ctr_x - 0.5 * pred_w,
+            pred_ctr_y - 0.5 * pred_h,
+            pred_ctr_x + 0.5 * pred_w,
+            pred_ctr_y + 0.5 * pred_h,
+        ],
+        dim=1,
+    )
+    return pred_boxes


### PR DESCRIPTION
This PR adds support for the SSD-MobileNet-V1 model in PyTorch.

The weights are extracted from the TensorFlow implementation, and converted on-the-fly during execution.

It matches the results reported in [the TensorFlow Object Detection ModelZoo](https://github.com/tensorflow/models/blob/master/research/object_detection/g3doc/detection_model_zoo.md#coco-trained-models), and by setting `score_threshold` to 0.01 (instead of 0.3), we obtain 24 mAP during testing on the full COCO 2017 val.