### PR TITLE
Update MobileNet's READMEs

### DIFF
--- a/edge/object_classification/mobilenets/README.md
+++ b/edge/object_classification/mobilenets/README.md
@@ -79,10 +79,9 @@ $ ck install package:imagenet-2012-val-min
 $ ck install package:imagenet-2012-val
 ```
 
-**NB:** If you already have the ImageNet validation dataset downloaded in a directory e.g. `$HOME/dataset-imagenet-ilsvrc2012-val/`, you can simply detect it as follows:
+**NB:** If you already have the ImageNet validation dataset downloaded in a directory e.g. `$HOME/ilsvrc2012-val/`, you can simply detect it as follows:
 ```bash
-$ ck detect soft:dataset.imagenet.val \
-  --full_path=$HOME/dataset-imagenet-ilsvrc2012-val/ILSVRC2012_val_00000001.JPEG
+$ ck detect soft:dataset.imagenet.val --full_path=$HOME/ilsvrc2012-val/ILSVRC2012_val_00000001.JPEG
 ```
 
 <a name="benchmarking"></a>

--- a/edge/object_classification/mobilenets/README.md
+++ b/edge/object_classification/mobilenets/README.md
@@ -51,11 +51,12 @@ the TensorFlow Lite benchmark (recommended) and TensorFlow (C++) benchmark (not 
 On Debian Linux, you can install the [Android SDK](https://developer.android.com/studio/) and the [Android NDK](https://developer.android.com/ndk/) as follows:
 ```
 $ sudo apt install android-sdk
-$ sudo apt install google-android-ndk-installer
 $ adb version
 Android Debug Bridge version 1.0.36
 Revision 1:7.0.0+r33-2
+$ sudo apt install google-android-ndk-installer
 ```
+**NB:** On Ubuntu 18.04, NDK r13b gets installed. On Ubuntu 16.04, download [NDK r18b](https://dl.google.com/android/repository/android-ndk-r18b-linux-x86_64.zip) and extract it into e.g. `/usr/local`. NDK r18c only supports LLVM, which currently requires a CK quirk to work properly (removing a dependency on `soft:compiler.gcc.android.ndk` from `soft:compiler.llvm.android.ndk`).
 
 <a name="installation-workflows"></a>
 ## Install CK workflows for MLPerf

--- a/edge/object_classification/mobilenets/README.md
+++ b/edge/object_classification/mobilenets/README.md
@@ -1,11 +1,11 @@
 [![compatibility](https://github.com/ctuning/ck-guide-images/blob/master/ck-compatible.svg)](https://github.com/ctuning/ck)
 [![License](https://img.shields.io/badge/License-BSD%203--Clause-blue.svg)](https://opensource.org/licenses/BSD-3-Clause)
 
-# MLPerf Inference - Object Classification - MobileNets
+# MLPerf Inference - Object Classification - MobileNet
 - [MobileNets: Efficient Convolutional Neural Networks for Mobile Vision Applications](https://arxiv.org/abs/1704.04861) (Howard et al., 2017)
 - [MobileNetV2: Inverted Residuals and Linear Bottlenecks ](https://arxiv.org/abs/1801.04381) (Sandler et al., 2018)
 
-**NB:** MLPerf Inference v0.5 uses MobileNet-v1-1.0-224.
+**NB:** MLPerf Inference v0.5 uses MobileNets-v1-1.0-224 (called MobileNet in what follows).
 
 # Table of contents
 

--- a/edge/object_classification/mobilenets/README.md
+++ b/edge/object_classification/mobilenets/README.md
@@ -27,14 +27,14 @@
 - (Optional) [Android SDK](https://developer.android.com/studio/), [Android NDK](https://developer.android.com/ndk/).
 
 ### Install common tools and libraries
-```
+```bash
 $ sudo apt install autoconf autogen libtool zlib1g-dev
 $ sudo apt install gcc g++ git wget
 $ sudo apt install libblas-dev liblapack-dev
 ```
 
 ### Install Python, pip, SciPy and CK
-```
+```bash
 $ sudo apt install python3 python3-pip
 $ sudo python3 -m pip install scipy
 $ sudo python3 -m pip install ck
@@ -62,13 +62,24 @@ $ sudo apt install google-android-ndk-installer
 ## Install CK workflows for MLPerf
 
 ### Pull CK repositories
-```
+```bash
 $ ck pull repo:ck-mlperf
 ```
 **NB:** Transitive dependencies include [repo:ck-tensorflow](https://github.com/ctuning/ck-tensorflow).
 
 ### Install a small dataset (500 images)
-```
+```bash
 $ ck install package:imagenet-2012-val-min 
 ```
-**NB:** ImageNet dataset descriptions are contained in [repo:ck-env](https://github.com/ctuning/ck-env).
+**NB:** ImageNet dataset descriptions are in [repo:ck-env](https://github.com/ctuning/ck-env).
+
+### Install the full dataset (50,000 images)
+```bash
+$ ck install package:imagenet-2012-val
+```
+
+**NB:** If you already have the ImageNet validation dataset downloaded in a directory e.g. `$HOME/dataset-imagenet-ilsvrc2012-val/`, you can simply detect it as follows:
+```bash
+$ ck detect soft:dataset.imagenet.val \
+  --full_path=$HOME/dataset-imagenet-ilsvrc2012-val/ILSVRC2012_val_00000001.JPEG
+```

--- a/edge/object_classification/mobilenets/README.md
+++ b/edge/object_classification/mobilenets/README.md
@@ -5,6 +5,10 @@
 - [MobileNets: Efficient Convolutional Neural Networks for Mobile Vision Applications](https://arxiv.org/abs/1704.04861) (Howard et al., 2017)
 - [MobileNetV2: Inverted Residuals and Linear Bottlenecks ](https://arxiv.org/abs/1801.04381) (Sandler et al., 2018)
 
+**NB:** MLPerf Inference v0.5 uses MobileNet-v1-1.0-224.
+
+# Table of contents
+
 1. [Installation](#installation)
     1. [Install prerequisites](#installation-debian) (Debian-specific)
     1. [Install CK workflows](#installation-workflows) (universal)
@@ -16,7 +20,7 @@
 # Installation
 
 <a name="installation-debian"></a>
-## Debian (last tested with Ubuntu v18.04)
+## Debian (tested with Ubuntu v18.04 and v16.04)
 
 - Common tools and libraries.
 - [Python](https://www.python.org/), [pip](https://pypi.org/project/pip/), [SciPy](https://www.scipy.org/), [Collective Knowledge](https://cknowledge.org) (CK).
@@ -54,12 +58,13 @@ Revision 1:7.0.0+r33-2
 ```
 
 <a name="installation-workflows"></a>
-## Install CK workflows
+## Install CK workflows for MLPerf
 
 ### Pull CK repositories
 ```
-$ ck pull repo:ck-tensorflow
+$ ck pull repo:ck-mlperf
 ```
+**NB:** Transitive dependencies include [repo:ck-tensorflow](https://github.com/ctuning/ck-tensorflow).
 
 ### Install a small dataset (500 images)
 ```

--- a/edge/object_classification/mobilenets/README.md
+++ b/edge/object_classification/mobilenets/README.md
@@ -10,11 +10,12 @@
 # Table of contents
 
 1. [Installation](#installation)
-    1. [Install prerequisites](#installation-debian) (Debian-specific)
-    1. [Install CK workflows](#installation-workflows) (universal)
-1. [Benchmark MobileNets via TensorFlow Lite](tflite/README.md)
-1. [Benchmark MobileNets via TensorFlow (C++)](tf-cpp/README.md)
-1. [Benchmark MobileNets via TensorFlow (Python)](tf-py/README.md)
+    - [Install prerequisites](#installation-debian) (Debian-specific)
+    - [Install CK workflows](#installation-workflows) (universal)
+1. [Benchmarking](#benchmarking)
+    - [via TensorFlow Lite](tflite/README.md)
+    - [via TensorFlow (C++)](tf-cpp/README.md)
+    - [via TensorFlow (Python)](tf-py/README.md)
 
 <a name="installation"></a>
 # Installation
@@ -83,3 +84,11 @@ $ ck install package:imagenet-2012-val
 $ ck detect soft:dataset.imagenet.val \
   --full_path=$HOME/dataset-imagenet-ilsvrc2012-val/ILSVRC2012_val_00000001.JPEG
 ```
+
+<a name="benchmarking"></a>
+## Benchmarking
+
+You can benchmark MobileNet using one of the available options:
+- [via TensorFlow Lite](tflite/README.md)
+- [via TensorFlow (C++)](tf-cpp/README.md)
+- [via TensorFlow (Python)](tf-py/README.md)

--- a/edge/object_classification/mobilenets/tf-cpp/README.md
+++ b/edge/object_classification/mobilenets/tf-cpp/README.md
@@ -21,12 +21,12 @@ To select interactively from one of the non-quantized and quantized MobileNets-v
 $ ck install package --tags=model,tf,mlperf,mobilenet
 ```
 
-To install the non-quantized model directly:
+To install the [non-quantized model](https://zenodo.org/record/2269307/files/mobilenet_v1_1.0_224.tgz) directly:
 ```
 $ ck install package --tags=model,tf,mlperf,mobilenet,non-quantized
 ```
 
-To install the quantized model directly:
+To install the [quantized model](http://download.tensorflow.org/models/mobilenet_v1_2018_08_02/mobilenet_v1_1.0_224_quant.tgz) directly:
 ```
 $ ck install package --tags=model,tf,mlperf,mobilenet,quantized
 ```

--- a/edge/object_classification/mobilenets/tf-cpp/README.md
+++ b/edge/object_classification/mobilenets/tf-cpp/README.md
@@ -2,7 +2,7 @@
 
 Please follow the common [installation instructions](../README.md#installation) first.
 
-**NB:** See the [TFLIte instructions](../tflite/README.md) how to use Collective Knowledge to learn more about the anatomy of the benchmark.
+**NB:** See the [TFLite instructions](../tflite/README.md) how to use Collective Knowledge to learn more about the anatomy of the benchmark.
 
 **NB:** See [`ck-tensorflow:program:image-classification-tf-cpp`](https://github.com/ctuning/ck-tensorflow/tree/master/program/image-classification-tf-cpp) for more details about the client program.
 

--- a/edge/object_classification/mobilenets/tf-cpp/README.md
+++ b/edge/object_classification/mobilenets/tf-cpp/README.md
@@ -2,23 +2,36 @@
 
 Please follow the common [installation instructions](../README.md#installation) first.
 
-**NB:** See [`ck-tensorflow:program:image-classification-tf-cpp`](https://github.com/ctuning/ck-tensorflow/tree/master/program/image-classification-tf-cpp) for more details.
+**NB:** See the [TFLIte instructions](../tflite/README.md) how to use Collective Knowledge to learn more about the anatomy of the benchmark.
+
+**NB:** See [`ck-tensorflow:program:image-classification-tf-cpp`](https://github.com/ctuning/ck-tensorflow/tree/master/program/image-classification-tf-cpp) for more details about the client program.
+
 
 ### Install TensorFlow (C++)
 
 Install TensorFlow (C++) from source:
 ```
-$ ck install package:lib-tensorflow-1.10.1-src-static [--target_os=android23-arm64]
+$ ck install package:lib-tensorflow-1.13.1-src-static [--target_os=android23-arm64]
 ```
 
 ### Install the MobileNets model for TensorFlow (C++)
 
-Install the MobileNets-v1-1.0-224 model adopted for MLPerf Inference v0.5:
+To select interactively from one of the non-quantized and quantized MobileNets-v1-1.0-224 models:
 ```
-$ ck install package --tags=tensorflowmodel,mobilenet,mlperf
+$ ck install package --tags=model,tf,mlperf,mobilenet
 ```
 
-NB: You can also install any other MobileNets model compatible with TensorFlow (C++) as follows:
+To install the non-quantized model directly:
+```
+$ ck install package --tags=model,tf,mlperf,mobilenet,non-quantized
+```
+
+To install the quantized model directly:
+```
+$ ck install package --tags=model,tf,mlperf,mobilenet,quantized
+```
+
+**NB:** You can also install any other MobileNets model compatible with TensorFlow (C++) as follows:
 ```
 $ ck install package --tags=tensorflowmodel,mobilenet,frozen
 ```
@@ -29,14 +42,17 @@ $ ck compile program:image-classification-tf-cpp [--target_os=android23-arm64]
 ```
 
 ### Run the TensorFlow (C++) image classification client
+
+Run the client (if required, connect an Android device to your host machine via USB):
+
+- with the non-quantized model:
 ```
 $ ck run program:image-classification-tf-cpp [--target_os=android23-arm64]
 ...
 *** Dependency 3 = weights (TensorFlow model and weights):
-    ...
+...
     Resolved. CK environment UID = f934f3a3faaf4d73 (version 1_1.0_224_2018_02_22)
 ...
----------------------------------------
 ILSVRC2012_val_00000001.JPEG - (65) n01751748 sea snake
 0.84 - (65) n01751748 sea snake
 0.08 - (58) n01737021 water snake

--- a/edge/object_classification/mobilenets/tf-cpp/README.md
+++ b/edge/object_classification/mobilenets/tf-cpp/README.md
@@ -153,7 +153,7 @@ $ ck benchmark program:image-classification-tf-cpp \
 --skip_print_timers --skip_stat_analysis --process_multi_keys
 ```
 **NB:** For the `imagenet-2012-val-min` dataset, change `--env.CK_BATCH_COUNT=50000`
-to `--env.CK_BATCH_COUNT=500` (or drop completely).
+to `--env.CK_BATCH_COUNT=500` (or drop completely to test on a single image with `CK_BATCH_COUNT=1`).
 
 #### Inspect the recorded results
 
@@ -166,33 +166,52 @@ $ ck list_points local:experiment:mlperf-mobilenet-tf-cpp-accuracy
 78dae6354e471199
 918c80bc5d4906b0
 ```
+You can then retrieve various run parameters from experimental points.
 
-You can quickly inspect the accuracy recorded for a particular model as follows:
+##### Accuracy
+You can quickly inspect the accuracy recorded for a particular point as follows:
 ```bash
 $ grep \"run\": -A2 /home/anton/CK_REPOS/local/experiment/mlperf-mobilenet-tf-cpp-accuracy/ckp-918c80bc5d4906b0.0001.json                                                           
       "run": {
         "accuracy_top1": 0.718, 
         "accuracy_top5": 0.9, 
-$ grep RUN_OPT_GRAPH_FILE /home/anton/CK_REPOS/local/experiment/mlperf-mobilenet-tf-cpp-accuracy/ckp-918c80bc5d4906b0.0001.json
-      "RUN_OPT_GRAPH_FILE": "/home/anton/CK_TOOLS/model-tf-mlperf-mobilenet-downloaded/mobilenet_v1_1.0_224_frozen.pb",
-
 $ grep \"run\": -A2 /home/anton/CK_REPOS/local/experiment/mlperf-mobilenet-tf-cpp-accuracy/ckp-78dae6354e471199.0001.json 
       "run": {
         "accuracy_top1": 0.704, 
         "accuracy_top5": 0.898, 
+```
+
+##### Model
+You can quickly inspect the model used for a particular point as follows:
+```bash
+$ grep RUN_OPT_GRAPH_FILE /home/anton/CK_REPOS/local/experiment/mlperf-mobilenet-tf-cpp-accuracy/ckp-918c80bc5d4906b0.0001.json
+      "RUN_OPT_GRAPH_FILE": "/home/anton/CK_TOOLS/model-tf-mlperf-mobilenet-downloaded/mobilenet_v1_1.0_224_frozen.pb",
 $ grep RUN_OPT_GRAPH_FILE /home/anton/CK_REPOS/local/experiment/mlperf-mobilenet-tf-cpp-accuracy/ckp-78dae6354e471199.0001.json
       "RUN_OPT_GRAPH_FILE": "/home/anton/CK_TOOLS/model-tf-mlperf-mobilenet-quantized-downloaded/mobilenet_v1_1.0_224_quant_frozen.pb",
 ```
+As expected, the lower accuracy the quantized model.
 
-**NB:** At the moment, the dataset path is recorded only to `pipeline.json`.
+
+##### Dataset
+Unfortunately, the dataset path is recorded only to `pipeline.json`.
 This file gets overwritten on each run of `ck benchmark`, so only
 the dataset used in the latest command can be retrieved:
 ```bash
 $ grep \"CK_ENV_DATASET_IMAGENET_VAL\": /home/anton/CK_REPOS/local/experiment/mlperf-mobilenet-tf-cpp-accuracy/pipeline.json
           "CK_ENV_DATASET_IMAGENET_VAL": "/home/anton/CK_TOOLS/dataset-imagenet-ilsvrc2012-val-min"
 ```
+
+##### Batch count
 You can, however, check the batch count e.g.:
 ```bash
 $ grep CK_BATCH_COUNT /home/anton/CK_REPOS/local/experiment/mlperf-mobilenet-tf-cpp-accuracy/ckp-78dae6354e471199.0001.json
       "CK_BATCH_COUNT": "500", 
 ```
+
+##### Image cropping
+By default, the program [crops](https://github.com/ctuning/ck-tensorflow/tree/master/program/image-classification-tf-cpp#ck_crop_percent) images by 87.5%:
+```bash
+$ grep CK_CROP_PERCENT /home/anton/CK_REPOS/local/experiment/mlperf-mobilenet-tf-cpp-accuracy/ckp-78dae6354e471199.0001.json
+      "CK_CROP_PERCENT": 87.5,
+```
+This can be changed by passing e.g. `CK_CROP_PERCENT=100` to `ck benchmark`.

--- a/edge/object_classification/mobilenets/tf-cpp/README.md
+++ b/edge/object_classification/mobilenets/tf-cpp/README.md
@@ -1,20 +1,25 @@
-# MobileNets via TensorFlow (C++)
+# MobileNet via TensorFlow (C++)
+
+1. [Installation instructions](#installation)
+2. [Benchmarking instructions](#benchmarking)
+
+**NB:** See the [TFLite instructions](../tflite/README.md) how to use Collective Knowledge to learn more about the [anatomy](../tflite/README.md#anatomy) of the benchmark.
+
+<a name="installation"></a>
+## Installation instructions
 
 Please follow the common [installation instructions](../README.md#installation) first.
 
-**NB:** See the [TFLite instructions](../tflite/README.md) how to use Collective Knowledge to learn more about the anatomy of the benchmark.
-
 **NB:** See [`ck-tensorflow:program:image-classification-tf-cpp`](https://github.com/ctuning/ck-tensorflow/tree/master/program/image-classification-tf-cpp) for more details about the client program.
-
 
 ### Install TensorFlow (C++)
 
 Install TensorFlow (C++) from source:
-```
+```bash
 $ ck install package:lib-tensorflow-1.13.1-src-static [--target_os=android23-arm64]
 ```
 
-### Install the MobileNets model for TensorFlow (C++)
+### Install the MobileNet model for TensorFlow (C++)
 
 To select interactively from one of the non-quantized and quantized MobileNets-v1-1.0-224 models:
 ```
@@ -22,22 +27,22 @@ $ ck install package --tags=model,tf,mlperf,mobilenet
 ```
 
 To install the [non-quantized model](https://zenodo.org/record/2269307/files/mobilenet_v1_1.0_224.tgz) directly:
-```
+```bash
 $ ck install package --tags=model,tf,mlperf,mobilenet,non-quantized
 ```
 
 To install the [quantized model](http://download.tensorflow.org/models/mobilenet_v1_2018_08_02/mobilenet_v1_1.0_224_quant.tgz) directly:
-```
+```bash
 $ ck install package --tags=model,tf,mlperf,mobilenet,quantized
 ```
 
 **NB:** You can also install any other MobileNets model compatible with TensorFlow (C++) as follows:
-```
+```bash
 $ ck install package --tags=tensorflowmodel,mobilenet,frozen
 ```
 
 ### Compile the TensorFlow (C++) image classification client
-```
+```bash
 $ ck compile program:image-classification-tf-cpp [--target_os=android23-arm64]
 ```
 
@@ -46,7 +51,7 @@ $ ck compile program:image-classification-tf-cpp [--target_os=android23-arm64]
 Run the client (if required, connect an Android device to your host machine via USB):
 
 - with the non-quantized model:
-```
+```bash
 $ ck run program:image-classification-tf-cpp [--target_os=android23-arm64]
 ...
 *** Dependency 3 = weights (TensorFlow model and weights):
@@ -73,7 +78,7 @@ Accuracy top 5: 1.0 (1 of 1)
 ```
 
 - with the quantized model:
-```
+```bash
 $ ck run program:image-classification-tf-cpp [--target_os=android23-arm64]
 ...
 *** Dependency 3 = weights (TensorFlow model and weights):
@@ -97,4 +102,97 @@ Average classification time: 0.568562s
 Accuracy top 1: 1.0 (1 of 1)
 Accuracy top 5: 1.0 (1 of 1)
 --------------------------------
+```
+
+<a name="benchmarking"></a>
+## Benchmarking instructions
+
+### Benchmark the performance
+```
+$ ck benchmark program:image-classification-tf-cpp \
+--repetitions=10 --env.CK_BATCH_SIZE=1 --env.CK_BATCH_COUNT=2 \
+--record --record_repo=local --record_uoa=mlperf-mobilenet-tf-cpp-performance \
+--tags=image-classification,mlperf,mobilenet,tf,tf-cpp,performance \
+--skip_print_timers --skip_stat_analysis --process_multi_keys
+```
+
+**NB:** When using the batch count of **N**, the program classifies **N** images, but
+the slow first run is not taken into account when computing the average
+classification time e.g.:
+```bash
+$ ck benchmark program:image-classification-tf-cpp \
+--repetitions=10 --env.CK_BATCH_SIZE=1 --env.CK_BATCH_COUNT=2
+...
+Processing batches...
+
+Batch 1 of 2
+Batch loaded in 0.00341696 s
+Batch classified in 0.355268 s
+
+Batch 2 of 2
+Batch loaded in 0.00335902 s
+Batch classified in 0.0108837 s
+...
+Summary:
+-------------------------------
+Graph loaded in 0.053440s
+All images loaded in 0.006776s
+All images classified in 0.366151s
+Average classification time: 0.010884s
+Accuracy top 1: 0.5 (1 of 2)
+Accuracy top 5: 1.0 (2 of 2)
+--------------------------------
+```
+
+### Benchmark the accuracy
+```bash
+$ ck benchmark program:image-classification-tf-cpp \
+--repetitions=1  --env.CK_BATCH_SIZE=1 --env.CK_BATCH_COUNT=50000 \
+--record --record_repo=local --record_uoa=mlperf-mobilenet-tf-cpp-accuracy \
+--tags=image-classification,mlperf,mobilenet,tf,tf-cpp,accuracy \
+--skip_print_timers --skip_stat_analysis --process_multi_keys
+```
+**NB:** For the `imagenet-2012-val-min` dataset, change `--env.CK_BATCH_COUNT=50000`
+to `--env.CK_BATCH_COUNT=500` (or drop completely).
+
+#### Inspect the recorded results
+
+If you run the same command several times selecting different models (quantized or non-quantized)
+or datasets (500 images or 50,000 images), CK will create several _experimental points_ in the same repository e.g.:
+```bash
+$ ck find local:experiment:mlperf-mobilenet-tf-cpp-accuracy
+/home/anton/CK_REPOS/local/experiment/mlperf-mobilenet-tf-cpp-accuracy
+$ ck list_points local:experiment:mlperf-mobilenet-tf-cpp-accuracy
+78dae6354e471199
+918c80bc5d4906b0
+```
+
+You can quickly inspect the accuracy recorded for a particular model as follows:
+```bash
+$ grep \"run\": -A2 /home/anton/CK_REPOS/local/experiment/mlperf-mobilenet-tf-cpp-accuracy/ckp-918c80bc5d4906b0.0001.json                                                           
+      "run": {
+        "accuracy_top1": 0.718, 
+        "accuracy_top5": 0.9, 
+$ grep RUN_OPT_GRAPH_FILE /home/anton/CK_REPOS/local/experiment/mlperf-mobilenet-tf-cpp-accuracy/ckp-918c80bc5d4906b0.0001.json
+      "RUN_OPT_GRAPH_FILE": "/home/anton/CK_TOOLS/model-tf-mlperf-mobilenet-downloaded/mobilenet_v1_1.0_224_frozen.pb",
+
+$ grep \"run\": -A2 /home/anton/CK_REPOS/local/experiment/mlperf-mobilenet-tf-cpp-accuracy/ckp-78dae6354e471199.0001.json 
+      "run": {
+        "accuracy_top1": 0.704, 
+        "accuracy_top5": 0.898, 
+$ grep RUN_OPT_GRAPH_FILE /home/anton/CK_REPOS/local/experiment/mlperf-mobilenet-tf-cpp-accuracy/ckp-78dae6354e471199.0001.json
+      "RUN_OPT_GRAPH_FILE": "/home/anton/CK_TOOLS/model-tf-mlperf-mobilenet-quantized-downloaded/mobilenet_v1_1.0_224_quant_frozen.pb",
+```
+
+**NB:** At the moment, the dataset path is recorded only to `pipeline.json`.
+This file gets overwritten on each run of `ck benchmark`, so only
+the dataset used in the latest command can be retrieved:
+```bash
+$ grep \"CK_ENV_DATASET_IMAGENET_VAL\": /home/anton/CK_REPOS/local/experiment/mlperf-mobilenet-tf-cpp-accuracy/pipeline.json
+          "CK_ENV_DATASET_IMAGENET_VAL": "/home/anton/CK_TOOLS/dataset-imagenet-ilsvrc2012-val-min"
+```
+You can, however, check the batch count e.g.:
+```bash
+$ grep CK_BATCH_COUNT /home/anton/CK_REPOS/local/experiment/mlperf-mobilenet-tf-cpp-accuracy/ckp-78dae6354e471199.0001.json
+      "CK_BATCH_COUNT": "500", 
 ```

--- a/edge/object_classification/mobilenets/tf-cpp/README.md
+++ b/edge/object_classification/mobilenets/tf-cpp/README.md
@@ -71,3 +71,30 @@ Accuracy top 1: 1.0 (1 of 1)
 Accuracy top 5: 1.0 (1 of 1)
 --------------------------------
 ```
+
+- with the quantized model:
+```
+$ ck run program:image-classification-tf-cpp [--target_os=android23-arm64]
+...
+*** Dependency 3 = weights (TensorFlow model and weights):
+...
+    Resolved. CK environment UID = b18ad885d440dc77 (version 1_1.0_224_quant_2018_08_02)
+...
+ILSVRC2012_val_00000001.JPEG - (65) n01751748 sea snake
+0.72 - (65) n01751748 sea snake
+0.16 - (58) n01737021 water snake
+0.05 - (54) n01729322 hognose snake, puff adder, sand viper
+0.03 - (34) n01665541 leatherback turtle, leatherback, leather...
+0.01 - (50) n01698640 American alligator, Alligator mississipi...
+---------------------------------------
+
+Summary:
+-------------------------------
+Graph loaded in 0.096074s
+All images loaded in 0.004774s
+All images classified in 0.568562s
+Average classification time: 0.568562s
+Accuracy top 1: 1.0 (1 of 1)
+Accuracy top 5: 1.0 (1 of 1)
+--------------------------------
+```

--- a/edge/object_classification/mobilenets/tf-py/README.md
+++ b/edge/object_classification/mobilenets/tf-py/README.md
@@ -2,26 +2,40 @@
 
 Please follow the common [installation instructions](../README.md#installation) first.
 
-**NB:** See [`ck-tensorflow:program:image-classification-tf-py`](https://github.com/ctuning/ck-tensorflow/tree/master/program/image-classification-tf-py) for more details.
+**NB:** See the [TFLite instructions](../tflite/README.md) how to use Collective Knowledge to learn more about the anatomy of the benchmark.
+
+**NB:** See [`ck-tensorflow:program:image-classification-tf-py`](https://github.com/ctuning/ck-tensorflow/tree/master/program/image-classification-tf-py) for more details about the client program.
+
 
 ### Install TensorFlow (Python)
 
-Install TensorFlow (Python) from an `x86_64` binary package (requires system `protobuf`):
+Install TensorFlow (Python) from an `x86_64` binary package (may still require system `protobuf`):
 ```
 $ sudo python3 -m pip install -U protobuf
-$ ck install package:lib-tensorflow-1.10.1-cpu
+$ ck install package:lib-tensorflow-1.13.1-cpu
 ```
 or from source:
 ```
-$ ck install package:lib-tensorflow-1.10.1-src-cpu
+$ ck install package:lib-tensorflow-1.13.1-src-cpu
 ```
 
 ### Install the MobileNets model for TensorFlow (Python)
 
-Install the MobileNets-v1-1.0-224 model adopted for MLPerf Inference v0.5:
+To select interactively from one of the non-quantized and quantized MobileNets-v1-1.0-224 models:
 ```
-$ ck install package --tags=tensorflowmodel,mobilenet,mlperf
+$ ck install package --tags=model,tf,mlperf,mobilenet
 ```
+
+To install the non-quantized model directly:
+```
+$ ck install package --tags=model,tf,mlperf,mobilenet,non-quantized
+```
+
+To install the quantized model directly:
+```
+$ ck install package --tags=model,tf,mlperf,mobilenet,quantized
+```
+
 
 **NB:** You can also install any other MobileNets model compatible with TensorFlow (Python) as follows:
 ```
@@ -36,29 +50,59 @@ ck-tensorflow:package:tensorflowmodel-mobilenet-v1
 ```
 
 ### Run the TensorFlow (Python) image classification client
+
+Run the client:
+
+- with the non-quantized model:
 ```
 $ ck run program:image-classification-tf-py
 ...
 *** Dependency 4 = weights (TensorFlow-Python model and weights):
-    ...
+...
     Resolved. CK environment UID = f934f3a3faaf4d73 (version 1_1.0_224_2018_02_22)
 ...
----------------------------------------
 ILSVRC2012_val_00000001.JPEG - (65) n01751748 sea snake
-0.82 - (65) n01751748 sea snake                                                                        
-0.10 - (58) n01737021 water snake     
+0.82 - (65) n01751748 sea snake
+0.10 - (58) n01737021 water snake
 0.04 - (34) n01665541 leatherback turtle, leatherback, leather...
 0.01 - (54) n01729322 hognose snake, puff adder, sand viper
 0.01 - (57) n01735189 garter snake, grass snake
 ---------------------------------------
-                                   
-Summary:                             
--------------------------------    
-Graph loaded in 0.855126s           
-All images loaded in 0.001089s                   
+
+Summary:
+-------------------------------
+Graph loaded in 0.855126s
+All images loaded in 0.001089s
 All images classified in 0.116698s
 Average classification time: 0.116698s
-Accuracy top 1: 1.0 (1 of 1)                     
-Accuracy top 5: 1.0 (1 of 1)                 
--------------------------------- 
+Accuracy top 1: 1.0 (1 of 1)
+Accuracy top 5: 1.0 (1 of 1)
+--------------------------------
+```
+
+- with the quantized model:
+```
+$ ck run program:image-classification-tf-py
+...
+*** Dependency 4 = weights (TensorFlow-Python model and weights):
+...
+    Resolved. CK environment UID = b18ad885d440dc77 (version 1_1.0_224_quant_2018_08_02)
+...
+ILSVRC2012_val_00000001.JPEG - (65) n01751748 sea snake
+0.16 - (60) n01740131 night snake, Hypsiglena torquata
+0.10 - (600) n03532672 hook, claw
+0.07 - (58) n01737021 water snake
+0.05 - (398) n02666196 abacus
+0.05 - (79) n01784675 centipede
+---------------------------------------
+
+Summary:
+-------------------------------
+Graph loaded in 1.066851s
+All images loaded in 0.001507s
+All images classified in 0.178281s
+Average classification time: 0.178281s
+Accuracy top 1: 0.0 (0 of 1)
+Accuracy top 5: 0.0 (0 of 1)
+--------------------------------
 ```

--- a/edge/object_classification/mobilenets/tf-py/README.md
+++ b/edge/object_classification/mobilenets/tf-py/README.md
@@ -1,4 +1,4 @@
-# MobileNets via TensorFlow (Python)
+# MobileNet via TensorFlow (Python)
 
 Please follow the common [installation instructions](../README.md#installation) first.
 
@@ -19,7 +19,7 @@ or from source:
 $ ck install package:lib-tensorflow-1.13.1-src-cpu
 ```
 
-### Install the MobileNets model for TensorFlow (Python)
+### Install the MobileNet model for TensorFlow (Python)
 
 To select interactively from one of the non-quantized and quantized MobileNets-v1-1.0-224 models:
 ```

--- a/edge/object_classification/mobilenets/tf-py/README.md
+++ b/edge/object_classification/mobilenets/tf-py/README.md
@@ -26,12 +26,12 @@ To select interactively from one of the non-quantized and quantized MobileNets-v
 $ ck install package --tags=model,tf,mlperf,mobilenet
 ```
 
-To install the non-quantized model directly:
+To install the [non-quantized model](https://zenodo.org/record/2269307/files/mobilenet_v1_1.0_224.tgz) directly:
 ```
 $ ck install package --tags=model,tf,mlperf,mobilenet,non-quantized
 ```
 
-To install the quantized model directly:
+To install the [quantized model](http://download.tensorflow.org/models/mobilenet_v1_2018_08_02/mobilenet_v1_1.0_224_quant.tgz) directly:
 ```
 $ ck install package --tags=model,tf,mlperf,mobilenet,quantized
 ```

--- a/edge/object_classification/mobilenets/tflite/README.md
+++ b/edge/object_classification/mobilenets/tflite/README.md
@@ -15,7 +15,7 @@ Please follow the common [installation instructions](../README.md#installation) 
 
 Install TFLite from source:
 ```
-$ ck install package:lib-tflite-0.1.7-src-static [--target_os=android23-arm64]
+$ ck install package:lib-tflite-1.13.1-src-static [--target_os=android23-arm64]
 ```
 
 You can also install TFLite from a prebuilt binary package for your target e.g.:
@@ -26,10 +26,13 @@ lib-tflite-prebuilt-0.1.7-linux-x64
 lib-tflite-prebuilt-0.1.7-android-arm64
 $ ck install package:lib-tflite-prebuilt-0.1.7-android-arm64 [--target_os=android23-arm64]
 ```
+**NB:** Currently we have no TFLite 1.13.1 prebuilt packages.
+Please [let us know](info@dividiti.com) if you would like us to create some.
+
 
 ### Install the MobileNets models for TFLite
 
-To select interactively from one of the non-quantized and quantized MobileNets-v1-1.0-224 models:
+To select interactively from one of the non-quantized and quantized MobileNets-v1-1.0-224 models adopted for MLPerf Inference v0.5:
 ```
 $ ck install package --tags=model,tflite,mlperf,mobilenet
 ```
@@ -119,8 +122,8 @@ Accuracy top 5: 1.0 (1 of 1)
 ```
 $ ck benchmark program:image-classification-tflite \
 --repetitions=10 --env.CK_BATCH_SIZE=1 --env.CK_BATCH_COUNT=2 \
---record --record_repo=local --record_uoa=mlperf-mobilenet-v1-1.00-224-tflite-0.1.7-performance \
---tags=mlperf,image-classification,mobilenet-v1-1.0-224,tflite-0.1.7,performance \
+--record --record_repo=local --record_uoa=mlperf-mobilenet-tflite-performance \
+--tags=image-classification,mlperf,mobilenet,tflite,performance \
 --skip_print_timers --skip_stat_analysis --process_multi_keys
 ```
 
@@ -158,8 +161,8 @@ Accuracy top 5: 1.0 (2 of 2)
 ```
 $ ck benchmark program:image-classification-tflite \
 --repetitions=1  --env.CK_BATCH_SIZE=1 --env.CK_BATCH_COUNT=50000 \
---record --record_repo=local --record_uoa=mlperf-mobilenet-v1-1.00-224-tflite-0.1.7-accuracy \
---tags=mlperf,image-classification,mobilenet-v1-1.0-224,tflite-0.1.7,accuracy \
+--record --record_repo=local --record_uoa=mlperf-mobilenet-tflite-accuracy \
+--tags=image-classification,mlperf,mobilenet,tflite,accuracy \
 --skip_print_timers --skip_stat_analysis --process_multi_keys
 ```
 

--- a/edge/object_classification/mobilenets/tflite/README.md
+++ b/edge/object_classification/mobilenets/tflite/README.md
@@ -1,4 +1,4 @@
-# MobileNets via TensorFlow Lite
+# MobileNet via TensorFlow Lite
 
 1. [Installation instructions](#installation)
 2. [Benchmarking instructions](#benchmarking)
@@ -30,7 +30,7 @@ $ ck install package:lib-tflite-prebuilt-0.1.7-android-arm64 [--target_os=androi
 Please [let us know](info@dividiti.com) if you would like us to create some.
 
 
-### Install the MobileNets models for TFLite
+### Install the MobileNet models for TFLite
 
 To select interactively from one of the non-quantized and quantized MobileNets-v1-1.0-224 models adopted for MLPerf Inference v0.5:
 ```

--- a/edge/object_classification/mobilenets/tflite/README.md
+++ b/edge/object_classification/mobilenets/tflite/README.md
@@ -27,11 +27,21 @@ lib-tflite-prebuilt-0.1.7-android-arm64
 $ ck install package:lib-tflite-prebuilt-0.1.7-android-arm64 [--target_os=android23-arm64]
 ```
 
-### Install the MobileNets model for TFLite
+### Install the MobileNets models for TFLite
 
-Install the MobileNets-v1-1.0-224 model adopted for MLPerf Inference v0.5:
+To select interactively from one of the non-quantized and quantized MobileNets-v1-1.0-224 models:
 ```
-$ ck install package --tags=tensorflowmodel,mobilenet,mlperf
+$ ck install package --tags=model,tflite,mlperf,mobilenet
+```
+
+To install the non-quantized model directly:
+```
+$ ck install package --tags=model,tflite,mlperf,mobilenet,non-quantized
+```
+
+To install the quantized model directly:
+```
+$ ck install package --tags=model,tflite,mlperf,mobilenet,quantized
 ```
 
 **NB:** You can also install any other MobileNets model compatible with TFLite as follows:
@@ -47,14 +57,15 @@ $ ck compile program:image-classification-tflite [--target_os=android23-arm64]
 ### Run the TFLite image classification client once
 
 Run the client (if required, connect an Android device to your host machine via USB):
+
+- with the non-quantized model:
 ```
 $ ck run program:image-classification-tflite [--target_os=android23-arm64]
 ...
 *** Dependency 3 = weights (TensorFlow-Python model and weights):
-
+...
     Resolved. CK environment UID = 4edbb2648a48d94d (version 1_1.0_224_2018_08_02)
 ...
-
 ILSVRC2012_val_00000001.JPEG - (65) n01751748 sea snake
 0.84 - (65) n01751748 sea snake
 0.08 - (58) n01737021 water snake
@@ -65,10 +76,37 @@ ILSVRC2012_val_00000001.JPEG - (65) n01751748 sea snake
 
 Summary:
 -------------------------------
-Graph loaded in 0.001723s
-All images loaded in 0.025555s
-All images classified in 0.391207s
-Average classification time: 0.391207s
+Graph loaded in 0.000860s
+All images loaded in 0.007685s
+All images classified in 0.173653s
+Average classification time: 0.173653s
+Accuracy top 1: 1.0 (1 of 1)
+Accuracy top 5: 1.0 (1 of 1)
+--------------------------------
+```
+
+- with the quantized model:
+```
+$ ck run program:image-classification-tflite [--target_os=android23-arm64]
+...
+*** Dependency 3 = weights (TensorFlow-Python model and weights):
+...
+    Resolved. CK environment UID = 3f0ca5c4d25b4ea3 (version 1_1.0_224_quant_2018_08_02)
+...
+ILSVRC2012_val_00000001.JPEG - (65) n01751748 sea snake
+0.80 - (65) n01751748 sea snake
+0.09 - (34) n01665541 leatherback turtle, leatherback, leather...
+0.05 - (58) n01737021 water snake
+0.03 - (54) n01729322 hognose snake, puff adder, sand viper
+0.00 - (33) n01664065 loggerhead, loggerhead turtle, Caretta c...
+---------------------------------------
+
+Summary:
+-------------------------------
+Graph loaded in 0.000589s
+All images loaded in 0.000290s
+All images classified in 0.450257s
+Average classification time: 0.450257s
 Accuracy top 1: 1.0 (1 of 1)
 Accuracy top 5: 1.0 (1 of 1)
 --------------------------------
@@ -135,70 +173,81 @@ describes the anatomy of the benchmark in terms of its components.
 
 ### Model
 
-To view the CK entry of the installed model:
+To view the CK entry of an installed model:
 ```
-$ ck search env --tags=tensorflowmodel,mobilenet,tflite
-local:env:4edbb2648a48d94d
-```
-
-To view more information about the CK entry:
-```
-$ ck show env --tags=tensorflowmodel,mobilenet,tflite
-Env UID:         Target OS: Bits: Name:                                                                 Version:             Tags:
-
-4edbb2648a48d94d   linux-64    64 TensorFlow python model and weights (mobilenet-v1-1.0-224-2018_08_02) 1_1.0_224_2018_08_02 2018_08_02,64bits,frozen,host-os-linux-64,mlperf,mobilenet,mobilenet-v1,mobilenet-v1-1.0-224,python,target-os-linux-64,tensorflowmodel,tflite,v1,v1.1,v1.1.0,v1.1.0.224,v1.1.0.224.2018,v1.1.0.224.2018.8,v1.1.0.224.2018.8.2,weights
+$ ck search env --tags=model,tflite,mlperf,mobilenet,quantized
+local:env:3f0ca5c4d25b4ea3
 ```
 
-To view the environment variables set up by the CK entry:
+To view more information about the model's CK entry:
 ```
-$ ck cat `ck search env --tags=tensorflowmodel,mobilenet,tflite`
+$ ck show env --tags=model,tflite,mlperf,mobilenet,quantized
+Env UID:         Target OS: Bits: Name:                                                                Version:                   Tags:
+
+3f0ca5c4d25b4ea3   linux-64    64 TensorFlow model and weights (mobilenet-v1-1.0-224-quant-2018_08_02) 1_1.0_224_quant_2018_08_02 2018_08_02,64bits,downloaded,host-os-linux-64,mlperf,mobilenet,mobilenet-v1,mobilenet-v1-1.0-224,model,nhwc,python,quantised,quantized,target-os-linux-64,tensorflowmodel,tf,tflite,v1,v1.1,v1.1.0,v1.1.0.224,v1.1.0.224.0,v1.1.0.224.0.2018,v1.1.0.224.0.2018.8,v1.1.0.224.0.2018.8.2,weights
+```
+
+To view the environment variables set up by the model's CK entry:
+```
+$ ck cat `ck search env --tags=model,tflite,mlperf,mobilenet,quantized`
 #! /bin/bash
 #
-# --------------------[ TensorFlow python model and weights (mobilenet-v1-1.0-224-2018_08_02) ver. 1_1.0_224_2018_08_02, /home/anton/CK_REPOS/local/env/4edbb2648a48d94d/env.sh ]--------------------
-# Tags: 2018_08_02,64bits,frozen,host-os-linux-64,mlperf,mobilenet,mobilenet-v1,mobilenet-v1-1.0-224,python,target-os-linux-64,tensorflowmodel,tflite,v1,v1.1,v1.1.0,v1.1.0.224,v1.1.0.224.2018,v1.1.0.224.2018.8,v1.1.0.224.2018.8.2,weights
+# --------------------[ TensorFlow model and weights (mobilenet-v1-1.0-224-quant-2018_08_02) ver. 1_1.0_224_quant_2018_08_02, /home/anton/CK_REPOS/local/env/3f0ca5c4d25b4ea3/env.sh ]--------------------
+# Tags: 2018_08_02,64bits,downloaded,host-os-linux-64,mlperf,mobilenet,mobilenet-v1,mobilenet-v1-1.0-224,model,nhwc,python,quantised,quantized,target-os-linux-64,tensorflowmodel,tf,tflite,v1,v1.1,v1.1.0,v1.1.0.224,v1.1.0.224.0,v1.1.0.224.0.2018,v1.1.0.224.0.2018.8,v1.1.0.224.0.2018.8.2,weights
 #
 # CK generated script
 
 if [ "$1" != "1" ]; then if [ "$CK_ENV_TENSORFLOW_MODEL_SET" == "1" ]; then return; fi; fi
 
-# Soft UOA           = model.tensorflow.py (439b9f1757f27091)  (tensorflowmodel,weights,python,frozen,tflite,mobilenet,mobilenet-v1,mobilenet-v1-1.0-224,2018_08_02,mlperf,host-os-linux-64,target-os-linux-64,64bits,v1,v1.1,v1.1.0,v1.1.0.224,v1.1.0.224.2018,v1.1.0.224.2018.8,v1.1.0.224.2018.8.2)
+# Soft UOA           = model.tensorflow.py (439b9f1757f27091)  (tensorflowmodel,model,weights,python,tf,tflite,nhwc,mobilenet,mobilenet-v1,mobilenet-v1-1.0-224,2018_08_02,quantized,quantised,mlperf,downloaded,host-os-linux-64,target-os-linux-64,64bits,v1,v1.1,v1.1.0,v1.1.0.224,v1.1.0.224.0,v1.1.0.224.0.2018,v1.1.0.224.0.2018.8,v1.1.0.224.0.2018.8.2)
 # Host OS UOA        = linux-64 (4258b5fe54828a50)
 # Target OS UOA      = linux-64 (4258b5fe54828a50)
 # Target OS bits     = 64
-# Tool version       = 1_1.0_224_2018_08_02
-# Tool split version = [1, 1, 0, 224, 2018, 8, 2]
+# Tool version       = 1_1.0_224_quant_2018_08_02
+# Tool split version = [1, 1, 0, 224, 0, 2018, 8, 2]
 
 export CK_ENV_TENSORFLOW_MODEL_IMAGE_HEIGHT=224
 export CK_ENV_TENSORFLOW_MODEL_IMAGE_WIDTH=224
+export CK_ENV_TENSORFLOW_MODEL_INPUT_LAYER_NAME=input
 export CK_ENV_TENSORFLOW_MODEL_MOBILENET_MULTIPLIER=1.0
 export CK_ENV_TENSORFLOW_MODEL_MOBILENET_RESOLUTION=224
 export CK_ENV_TENSORFLOW_MODEL_MOBILENET_VERSION=1
-export CK_ENV_TENSORFLOW_MODEL_MODULE=/home/anton/CK_TOOLS/tensorflowmodel-mobilenet-v1-1.0-224-2018_08_02-py/mobilenet-model.py
+export CK_ENV_TENSORFLOW_MODEL_MODULE=/home/anton/CK_TOOLS/model-tf-mlperf-mobilenet-quantized-downloaded/mobilenet-model.py
 export CK_ENV_TENSORFLOW_MODEL_NORMALIZE_DATA=YES
-export CK_ENV_TENSORFLOW_MODEL_WEIGHTS=/home/anton/CK_TOOLS/tensorflowmodel-mobilenet-v1-1.0-224-2018_08_02-py/mobilenet_v1_1.0_224.ckpt
+export CK_ENV_TENSORFLOW_MODEL_OUTPUT_LAYER_NAME=MobilenetV1/Predictions/Reshape_1
+export CK_ENV_TENSORFLOW_MODEL_ROOT=/home/anton/CK_TOOLS/model-tf-mlperf-mobilenet-quantized-downloaded
+export CK_ENV_TENSORFLOW_MODEL_TFLITE_FILENAME=mobilenet_v1_1.0_224_quant.tflite
+export CK_ENV_TENSORFLOW_MODEL_TFLITE_FILEPATH=/home/anton/CK_TOOLS/model-tf-mlperf-mobilenet-quantized-downloaded/mobilenet_v1_1.0_224_quant.tflite
+export CK_ENV_TENSORFLOW_MODEL_TF_FROZEN_FILENAME=mobilenet_v1_1.0_224_quant_frozen.pb
+export CK_ENV_TENSORFLOW_MODEL_TF_FROZEN_FILEPATH=/home/anton/CK_TOOLS/model-tf-mlperf-mobilenet-quantized-downloaded/mobilenet_v1_1.0_224_quant_frozen.pb
+export CK_ENV_TENSORFLOW_MODEL_WEIGHTS=/home/anton/CK_TOOLS/model-tf-mlperf-mobilenet-quantized-downloaded/mobilenet_v1_1.0_224_quant.ckpt
 export CK_ENV_TENSORFLOW_MODEL_WEIGHTS_ARE_CHECKPOINTS=YES
+export CK_MODEL_DATA_LAYOUT=NHWC
 
 export CK_ENV_TENSORFLOW_MODEL_SET=1
 ```
 
 To inspect the model's files on disk:
 ```
-$ ls -ls /home/anton/CK_TOOLS/tensorflowmodel-mobilenet-v1-1.0-224-2018_08_02-py
-total 102888
-drwxr-xr-x  2 anton dvdt     4096 Jan  2 17:57 .
-drwxr-xr-x 51 anton dvdt    12288 Jan  2 18:14 ..
--rw-r--r--  1 anton dvdt     2028 Jan  2 17:57 ck-install.json
--rw-r--r--  1 anton dvdt     3477 Jan  2 17:57 mobilenet-model.py
--rw-r--r--  1 anton dvdt 67903136 Aug  3 01:38 mobilenet_v1_1.0_224.ckpt.data-00000-of-00001
--rw-r--r--  1 anton dvdt    19954 Aug  3 01:38 mobilenet_v1_1.0_224.ckpt.index
--rw-r--r--  1 anton dvdt  3386971 Aug  3 01:38 mobilenet_v1_1.0_224.ckpt.meta
--rw-r--r--  1 anton dvdt 17085200 Aug  3 01:38 mobilenet_v1_1.0_224_frozen.pb
--rw-r--r--  1 anton dvdt       83 Aug  3 01:38 mobilenet_v1_1.0_224_info.txt
--rw-r--r--  1 anton dvdt 16901128 Aug  3 01:39 mobilenet_v1_1.0_224.tflite
--rw-r--r--  1 anton dvdt    20309 Jan  2 17:57 mobilenet_v1.py
+$ ck locate env --tags=model,tflite,mlperf,mobilenet,quantized
+/home/anton/CK_TOOLS/model-tf-mlperf-mobilenet-quantized-downloaded
+$ ls -la `ck locate env --tags=model,tflite,mlperf,mobilenet,quantized`
+total 43524
+drwxr-xr-x  2 anton dvdt     4096 Mar 25 12:31 .
+drwxrwxr-x 18 anton dvdt     4096 Mar 25 12:32 ..
+-rw-rw-r--  1 anton dvdt     2240 Mar 25 12:31 ck-install.json
+-rw-rw-r--  1 anton dvdt     3477 Mar 25 12:31 mobilenet-model.py
+-rw-rw-r--  1 anton dvdt    20309 Mar 25 12:31 mobilenet_v1.py
+-rw-r--r--  1 anton dvdt 17020468 Aug  3  2018 mobilenet_v1_1.0_224_quant.ckpt.data-00000-of-00001
+-rw-r--r--  1 anton dvdt    14644 Aug  3  2018 mobilenet_v1_1.0_224_quant.ckpt.index
+-rw-r--r--  1 anton dvdt  5143394 Aug  3  2018 mobilenet_v1_1.0_224_quant.ckpt.meta
+-rw-r--r--  1 anton dvdt  4276352 Aug  3  2018 mobilenet_v1_1.0_224_quant.tflite
+-rw-r--r--  1 anton dvdt   885850 Aug  3  2018 mobilenet_v1_1.0_224_quant_eval.pbtxt
+-rw-r--r--  1 anton dvdt 17173742 Aug  3  2018 mobilenet_v1_1.0_224_quant_frozen.pb
+-rw-r--r--  1 anton dvdt       89 Aug  3  2018 mobilenet_v1_1.0_224_quant_info.txt
 ```
 
-**NB:** The TFLite weights are in the `mobilenet_v1_1.0_224.tflite` file. Only
+**NB:** The TFLite weights are in the `mobilenet_v1_1.0_224*.tflite` file. Only
 the TFLite weights are different between the `2018_02_22` and `2018_08_02`
 MobileNets-v1 packages. We have adopted the latter for MLPerf Inference v0.5.
 

--- a/edge/object_classification/mobilenets/tflite/README.md
+++ b/edge/object_classification/mobilenets/tflite/README.md
@@ -34,12 +34,12 @@ To select interactively from one of the non-quantized and quantized MobileNets-v
 $ ck install package --tags=model,tflite,mlperf,mobilenet
 ```
 
-To install the non-quantized model directly:
+To install the [non-quantized model](https://zenodo.org/record/2269307/files/mobilenet_v1_1.0_224.tgz) directly:
 ```
 $ ck install package --tags=model,tflite,mlperf,mobilenet,non-quantized
 ```
 
-To install the quantized model directly:
+To install the [quantized model](http://download.tensorflow.org/models/mobilenet_v1_2018_08_02/mobilenet_v1_1.0_224_quant.tgz) directly:
 ```
 $ ck install package --tags=model,tflite,mlperf,mobilenet,quantized
 ```


### PR DESCRIPTION
We've made the following changes:
- Updated the recommended TensorFlow version from 1.10.1 to 1.13.1 for the TF programs (but not for the TFLite program yet).
- Added references to both non-quantized and quantized models with direct links. The former points to zenodo.org, while the latter still to tensorflow.org. (It's a good reminder to save the quantized model at zenodo.org too.)
- Included output from both non-quantized and quantized models. (More on this below.)