### PR TITLE
Fixes PyTorch SSD MobileNet V1

### DIFF
--- a/edge/object_detection/ssd_mobilenet/pytorch/README.md
+++ b/edge/object_detection/ssd_mobilenet/pytorch/README.md
@@ -9,7 +9,7 @@ It uses the pre-trained weight files from [the TensorFlow Object Detection Model
 - PyTorch 1.0 or later
 - torchvision
 - cocoapi
-- TensorFlow 1.12 (for loading the weights)
+- TensorFlow 1.12 or later (for loading the weights)
 
 ### Step-by-step installation with conda
 
@@ -24,8 +24,11 @@ conda activate pytorch_ssd_mobilenet
 # this installs the right pip and dependencies for the fresh python
 conda install ipython
 
+# coco api dependencies
+pip install cython matplotlib
+
 # follow PyTorch installation in https://pytorch.org/get-started/locally/
-# we give the instructions for CUDA 9.0
+# we give the instructions for CUDA 9.0 but you can pick whichever you prefer
 conda install -c pytorch pytorch torchvision cudatoolkit=9.0
 
 # install pycocotools

--- a/edge/object_detection/ssd_mobilenet/pytorch/README.md
+++ b/edge/object_detection/ssd_mobilenet/pytorch/README.md
@@ -57,12 +57,12 @@ python test_on_coco.py \
 ```
 which should give as a result
 ```
-2019-03-20 11:34:36.297500: I tensorflow/core/platform/cpu_feature_guard.cc:141] Your CPU supports instructions that this TensorFlow binary was not compiled to use: AVX2 FMA
-2019-03-20 11:34:36.325873: I tensorflow/core/platform/profile_utils/cpu_utils.cc:94] CPU Frequency: 2199815000 Hz
-2019-03-20 11:34:36.330036: I tensorflow/compiler/xla/service/service.cc:150] XLA service 0x5590161a41b0 executing computations on platform Host. Devices:
-2019-03-20 11:34:36.330057: I tensorflow/compiler/xla/service/service.cc:158]   StreamExecutor device (0): <undefined>, <undefined>
+2019-04-11 13:47:58.583262: I tensorflow/core/platform/cpu_feature_guard.cc:141] Your CPU supports instructions that this TensorFlow binary was not compiled to use: AVX2 FMA
+2019-04-11 13:47:58.613927: I tensorflow/core/platform/profile_utils/cpu_utils.cc:94] CPU Frequency: 2199815000 Hz
+2019-04-11 13:47:58.617907: I tensorflow/compiler/xla/service/service.cc:150] XLA service 0x5638b1a14b60 executing computations on platform Host. Devices:
+2019-04-11 13:47:58.617927: I tensorflow/compiler/xla/service/service.cc:158]   StreamExecutor device (0): <undefined>, <undefined>
 loading annotations into memory...
-Done (t=0.50s)
+Done (t=0.51s)
 creating index...
 index created!
 Loading and preparing results...
@@ -71,70 +71,70 @@ creating index...
 index created!
 Running per image evaluation...
 Evaluate annotation type *bbox*
-DONE (t=0.18s).
+DONE (t=0.13s).
 Accumulating evaluation results...
-DONE (t=0.18s).
- Average Precision  (AP) @[ IoU=0.50:0.95 | area=   all | maxDets=100 ] = 0.316
- Average Precision  (AP) @[ IoU=0.50      | area=   all | maxDets=100 ] = 0.444
- Average Precision  (AP) @[ IoU=0.75      | area=   all | maxDets=100 ] = 0.357
+DONE (t=0.24s).
+ Average Precision  (AP) @[ IoU=0.50:0.95 | area=   all | maxDets=100 ] = 0.321
+ Average Precision  (AP) @[ IoU=0.50      | area=   all | maxDets=100 ] = 0.440
+ Average Precision  (AP) @[ IoU=0.75      | area=   all | maxDets=100 ] = 0.366
  Average Precision  (AP) @[ IoU=0.50:0.95 | area= small | maxDets=100 ] = 0.062
- Average Precision  (AP) @[ IoU=0.50:0.95 | area=medium | maxDets=100 ] = 0.177
- Average Precision  (AP) @[ IoU=0.50:0.95 | area= large | maxDets=100 ] = 0.691
- Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets=  1 ] = 0.294
- Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets= 10 ] = 0.324
- Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets=100 ] = 0.324
- Average Recall     (AR) @[ IoU=0.50:0.95 | area= small | maxDets=100 ] = 0.062
- Average Recall     (AR) @[ IoU=0.50:0.95 | area=medium | maxDets=100 ] = 0.178
- Average Recall     (AR) @[ IoU=0.50:0.95 | area= large | maxDets=100 ] = 0.709
+ Average Precision  (AP) @[ IoU=0.50:0.95 | area=medium | maxDets=100 ] = 0.201
+ Average Precision  (AP) @[ IoU=0.50:0.95 | area= large | maxDets=100 ] = 0.693
+ Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets=  1 ] = 0.303
+ Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets= 10 ] = 0.330
+ Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets=100 ] = 0.330
+ Average Recall     (AR) @[ IoU=0.50:0.95 | area= small | maxDets=100 ] = 0.064
+ Average Recall     (AR) @[ IoU=0.50:0.95 | area=medium | maxDets=100 ] = 0.202
+ Average Recall     (AR) @[ IoU=0.50:0.95 | area= large | maxDets=100 ] = 0.712
 Summary:
 -------------------------------
-Setup time 7.618103981018066s
-All images loaded in 0.5562152862548828s
-All images detected in 1.1915736198425293s
-Average detection time: 0.024317828976378148s
-mAP: 0.3159874092405704
-Recall: 0.2940712479080072
+Setup time 12.216338157653809s
+All images loaded in 0.5750606060028076s
+All images detected in 1.1177282333374023s
+Average detection time: 0.022810780272191883s
+mAP: 0.32111795341882854
+Recall: 0.3033025069685554
 -------------------------------
 ```
 
 Here are the results when evaluating on the full 5000 images of COCO val2017
 ```
-2019-03-20 11:26:00.922253: I tensorflow/core/platform/cpu_feature_guard.cc:141] Your CPU supports instructions that this TensorFlow binary was not compiled to use: AVX2 FMA
-2019-03-20 11:26:00.949812: I tensorflow/core/platform/profile_utils/cpu_utils.cc:94] CPU Frequency: 2199815000 Hz
-2019-03-20 11:26:00.954376: I tensorflow/compiler/xla/service/service.cc:150] XLA service 0x55ad827e71b0 executing computations on platform Host. Devices:
-2019-03-20 11:26:00.954409: I tensorflow/compiler/xla/service/service.cc:158]   StreamExecutor device (0): <undefined>, <undefined>
+2019-04-11 13:41:24.266105: I tensorflow/core/platform/cpu_feature_guard.cc:141] Your CPU supports instructions that this TensorFlow binary was not compiled to use: AVX2 FMA
+2019-04-11 13:41:24.297876: I tensorflow/core/platform/profile_utils/cpu_utils.cc:94] CPU Frequency: 2199815000 Hz
+2019-04-11 13:41:24.302272: I tensorflow/compiler/xla/service/service.cc:150] XLA service 0x564bcd1f21a0 executing computations on platform Host. Devices:
+2019-04-11 13:41:24.302292: I tensorflow/compiler/xla/service/service.cc:158]   StreamExecutor device (0): <undefined>, <undefined>
 loading annotations into memory...
-Done (t=0.49s)
+Done (t=0.50s)
 creating index...
 index created!
 Loading and preparing results...
-DONE (t=0.21s)
+DONE (t=0.23s)
 creating index...
 index created!
 Running per image evaluation...
 Evaluate annotation type *bbox*
-DONE (t=10.37s).
+DONE (t=10.92s).
 Accumulating evaluation results...
-DONE (t=1.93s).
- Average Precision  (AP) @[ IoU=0.50:0.95 | area=   all | maxDets=100 ] = 0.205
- Average Precision  (AP) @[ IoU=0.50      | area=   all | maxDets=100 ] = 0.317
- Average Precision  (AP) @[ IoU=0.75      | area=   all | maxDets=100 ] = 0.226
- Average Precision  (AP) @[ IoU=0.50:0.95 | area= small | maxDets=100 ] = 0.015
- Average Precision  (AP) @[ IoU=0.50:0.95 | area=medium | maxDets=100 ] = 0.144
- Average Precision  (AP) @[ IoU=0.50:0.95 | area= large | maxDets=100 ] = 0.483
- Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets=  1 ] = 0.192
- Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets= 10 ] = 0.240
- Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets=100 ] = 0.240
- Average Recall     (AR) @[ IoU=0.50:0.95 | area= small | maxDets=100 ] = 0.018
- Average Recall     (AR) @[ IoU=0.50:0.95 | area=medium | maxDets=100 ] = 0.160
- Average Recall     (AR) @[ IoU=0.50:0.95 | area= large | maxDets=100 ] = 0.569
+DONE (t=1.82s).
+ Average Precision  (AP) @[ IoU=0.50:0.95 | area=   all | maxDets=100 ] = 0.231
+ Average Precision  (AP) @[ IoU=0.50      | area=   all | maxDets=100 ] = 0.351
+ Average Precision  (AP) @[ IoU=0.75      | area=   all | maxDets=100 ] = 0.254
+ Average Precision  (AP) @[ IoU=0.50:0.95 | area= small | maxDets=100 ] = 0.018
+ Average Precision  (AP) @[ IoU=0.50:0.95 | area=medium | maxDets=100 ] = 0.167
+ Average Precision  (AP) @[ IoU=0.50:0.95 | area= large | maxDets=100 ] = 0.528
+ Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets=  1 ] = 0.209
+ Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets= 10 ] = 0.263
+ Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets=100 ] = 0.263
+ Average Recall     (AR) @[ IoU=0.50:0.95 | area= small | maxDets=100 ] = 0.022
+ Average Recall     (AR) @[ IoU=0.50:0.95 | area=medium | maxDets=100 ] = 0.191
+ Average Recall     (AR) @[ IoU=0.50:0.95 | area= large | maxDets=100 ] = 0.602
 Summary:
 -------------------------------
-Setup time 8.944006204605103s
-All images loaded in 49.411635398864746s
-All images detected in 90.85995388031006s
-Average detection time: 0.01817562590124226s
-mAP: 0.20468113436884472
-Recall: 0.1923766276941554
+Setup time 11.774341344833374s
+All images loaded in 49.872482776641846s
+All images detected in 92.88805389404297s
+Average detection time: 0.018581327044217437s
+mAP: 0.2312394616636774
+Recall: 0.20853911034074307
 -------------------------------
 ```

--- a/edge/object_detection/ssd_mobilenet/pytorch/ssd_mobilenet_v1.py
+++ b/edge/object_detection/ssd_mobilenet/pytorch/ssd_mobilenet_v1.py
@@ -103,11 +103,11 @@ class Block(nn.Sequential):
     def __init__(self, in_channels, mid_channels, out_channels):
         super(Block, self).__init__(
             nn.Conv2d(in_channels, out_channels=mid_channels, kernel_size=1),
-            nn.ReLU(),
+            nn.ReLU6(),
             Conv2d_tf(
                 mid_channels, out_channels, kernel_size=3, stride=2, padding="SAME"
             ),
-            nn.ReLU(),
+            nn.ReLU6(),
         )
 
 
@@ -149,7 +149,7 @@ class SSD(nn.Module):
         class_logits = torch.cat(class_logits, 1)
         box_regression = torch.cat(box_regression, 1)
 
-        scores = F.softmax(class_logits, dim=2)
+        scores = torch.sigmoid(class_logits)
         box_regression = box_regression.squeeze(0)
 
         shapes = [o.shape[-2:] for o in feature_maps]


### PR DESCRIPTION
There were a couple of mistakes with the PyTorch implementation of SSD MobileNet V1 that lead to lower than expected mAP.

This PR fixes them, and also updates the README with the new results.
They now match the expected results from the original TensorFlow version.

cc @psyhtest