### PR TITLE
Update SSD-MobileNet reference

### DIFF
--- a/edge/object_classification/mobilenets/README.md
+++ b/edge/object_classification/mobilenets/README.md
@@ -69,9 +69,9 @@ $ CK_PYTHON=python3.6 ck python_version
 
 ### Install required Python 3 packages
 Choose one of the following installation options:
-- system-wide via pip;
-- user-space via pip;
-- user-space via CK.
+1. system-wide via pip;
+1. user-space via pip;
+1. user-space via CK.
 
 With the first two options, packages get installed via pip and get registered
 with CK later (typically, on the first run of a program).
@@ -79,15 +79,15 @@ with CK later (typically, on the first run of a program).
 With the last option, packages also get installed via pip but get registered
 with CK at the same time (so there is less chance of mixing things up).
 
-#### System-wide installation via pip (under `/usr`)
+#### Option 1: system-wide installation via pip (under `/usr`)
 ```bash
 $ sudo python3 -m pip install scipy ck
 ```
-#### User-space installation via pip (under `$HOME`)
+#### Option 2: user-space installation via pip (under `$HOME`)
 ```bash
 $ python3 -m pip install scipy ck --user
 ```
-#### User-space installation via CK (under `$HOME` and `$CK_TOOLS`)
+#### Option 3: User-space installation via CK (under `$HOME` and `$CK_TOOLS`)
 ```bash
 $ python3 -m pip install ck --user
 $ ck version

--- a/edge/object_classification/mobilenets/README.md
+++ b/edge/object_classification/mobilenets/README.md
@@ -88,14 +88,16 @@ $ sudo python3 -m pip install scipy ck
 $ python3 -m pip install scipy ck --user
 ```
 #### Option 3: User-space installation via CK (under `$HOME` and `$CK_TOOLS`)
+Install CK via pip (or [from GitHub](https://github.com/ctuning/ck#installation)):
 ```bash
 $ python3 -m pip install ck --user
 $ ck version
 V1.9.7
 ```
-**NB:** CK can also be installed [via Git](https://github.com/ctuning/ck#ubuntu).
 
+Install and register Python packages with CK:
 ```bash
+$ ck pull repo:ck-env
 $ ck detect soft:compiler.python --full_path=`which python3`
 $ ck install package --tags=lib,python-package,numpy
 $ ck install package --tags=lib,python-package,scipy

--- a/edge/object_classification/mobilenets/tf-cpp/README.md
+++ b/edge/object_classification/mobilenets/tf-cpp/README.md
@@ -15,13 +15,8 @@ Please follow the [common installation instructions](../README.md#installation) 
 
 Install TensorFlow (C++) v1.13.1 from source:
 ```bash
-$ ck install package:lib-tensorflow-1.13.1-src-static
+$ ck install package:lib-tensorflow-1.13.1-src-static [--target_os=android23-arm64]
 ```
-**NB:** We suggest you use v1.10.1 for Android:
-```
-$ ck install package:lib-tensorflow-1.10.1-src-static --target_os=android23-arm64
-```
-until a [linking issue](https://github.com/ctuning/ck-tensorflow/issues/113) is resolved.
 
 ### Install the MobileNet model for TensorFlow (C++)
 

--- a/edge/object_detection/ssd_mobilenet/README.md
+++ b/edge/object_detection/ssd_mobilenet/README.md
@@ -93,7 +93,7 @@ $ python3 -m pip install ck --user
 $ ck version
 V1.9.7
 ```
-
+Install and register Python packages with CK:
 ```bash
 $ ck pull repo:ck-env
 $ ck detect soft:compiler.python --full_path=`which python3`
@@ -101,7 +101,7 @@ $ ck install package --tags=lib,python-package,numpy
 $ ck install package --tags=lib,python-package,scipy
 $ ck install package --tags=lib,python-package,matplotlib
 $ ck install package --tags=lib,python-package,pillow
-$ python3 -m pip install cython --user
+$ python3 -m pip install cython --user && ck detect soft:lib.python.cython
 ```
 **NB:** Cython cannot be currently installed via CK (but we are working on it).
 

--- a/edge/object_detection/ssd_mobilenet/README.md
+++ b/edge/object_detection/ssd_mobilenet/README.md
@@ -140,7 +140,7 @@ $ ck pull repo --all
 
 ### Install the COCO 2017 validation dataset (5,000 images)
 ```bash
-$ ck install package:dataset-coco-2017-val
+$ ck install package --tags=dataset,coco,2017
 ```
 **NB:** COCO dataset descriptions are in [repo:ck-env](https://github.com/ctuning/ck-env).
 

--- a/edge/object_detection/ssd_mobilenet/README.md
+++ b/edge/object_detection/ssd_mobilenet/README.md
@@ -68,9 +68,9 @@ $ CK_PYTHON=python3.6 ck python_version
 
 ### Install required Python 3 packages
 Choose one of the following installation options:
-- system-wide via pip;
-- user-space via pip;
-- user-space via CK.
+1. system-wide via pip;
+1. user-space via pip;
+1. user-space via CK.
 
 With the first two options, packages get installed via pip and get registered
 with CK later (typically, on the first run of a program).
@@ -78,15 +78,15 @@ with CK later (typically, on the first run of a program).
 With the last option, packages also get installed via pip but get registered
 with CK at the same time (so there is less chance of mixing things up).
 
-#### System-wide installation via pip (under `/usr`)
+#### Option 1: system-wide installation via pip (under `/usr`)
 ```bash
 $ sudo python3 -m pip install cython scipy matplotlib pillow ck
 ```
-#### User-space installation via pip (under `$HOME`)
+#### Option 2: user-space installation via pip (under `$HOME`)
 ```bash
 $ python3 -m pip install cython scipy matplotlib pillow ck --user
 ```
-#### User-space installation via CK (under `$HOME` and `$CK_TOOLS`)
+#### Option 3: user-space installation via CK (under `$HOME` and `$CK_TOOLS`)
 ```bash
 $ python3 -m pip install ck --user
 $ ck version

--- a/edge/object_detection/ssd_mobilenet/README.md
+++ b/edge/object_detection/ssd_mobilenet/README.md
@@ -87,7 +87,7 @@ $ sudo python3 -m pip install cython scipy matplotlib pillow ck
 $ python3 -m pip install cython scipy matplotlib pillow ck --user
 ```
 #### Option 3: user-space installation via CK (under `$HOME` and `$CK_TOOLS`)
-Install CK via pip (or [via Git](https://github.com/ctuning/ck#ubuntu)):
+Install CK via pip (or [from GitHub](https://github.com/ctuning/ck#installation)):
 ```bash
 $ python3 -m pip install ck --user
 $ ck version
@@ -101,7 +101,7 @@ $ ck install package --tags=lib,python-package,numpy
 $ ck install package --tags=lib,python-package,scipy
 $ ck install package --tags=lib,python-package,matplotlib
 $ ck install package --tags=lib,python-package,pillow
-$ python3 -m pip install cython --user && ck detect soft:lib.python.cython
+$ python3 -m pip install cython --user && ck detect soft --tags=lib,python-package,cython
 ```
 **NB:** Cython cannot be currently installed via CK (but we are working on it).
 

--- a/edge/object_detection/ssd_mobilenet/README.md
+++ b/edge/object_detection/ssd_mobilenet/README.md
@@ -87,14 +87,15 @@ $ sudo python3 -m pip install cython scipy matplotlib pillow ck
 $ python3 -m pip install cython scipy matplotlib pillow ck --user
 ```
 #### Option 3: user-space installation via CK (under `$HOME` and `$CK_TOOLS`)
+Install CK via pip (or [via Git](https://github.com/ctuning/ck#ubuntu)):
 ```bash
 $ python3 -m pip install ck --user
 $ ck version
 V1.9.7
 ```
-**NB:** CK can also be installed [via Git](https://github.com/ctuning/ck#ubuntu).
 
 ```bash
+$ ck pull repo:ck-env
 $ ck detect soft:compiler.python --full_path=`which python3`
 $ ck install package --tags=lib,python-package,numpy
 $ ck install package --tags=lib,python-package,scipy

--- a/edge/object_detection/ssd_mobilenet/tf-py/README.md
+++ b/edge/object_detection/ssd_mobilenet/tf-py/README.md
@@ -235,8 +235,8 @@ Recall: 0.26864982712779556
 
 ### Using Collective Knowledge
 See the [common MobileNet instructions](../../../object_classification/mobilenets/README.md) for information on how to use Collective Knowledge
-to learn about [the anatomy of a benchmark](../../../object_clasification/mobilenets/README.md#anatomy), or
-to inspect and visualize [experimental results](../../../object_clasification/mobilenets/README.md#results).
+to learn about [the anatomy of a benchmark](../../../object_clasification/mobilenets/README.md#the-anatomy-of-a-benchmark), or
+to inspect and visualize [experimental results](../../../object_clasification/mobilenets/README.md#inspecting-recorded-experimental-results).
 
 ### Using the client program
 See [`ck-tensorflow:program:object-detection-tf-py`](https://github.com/ctuning/ck-tensorflow/tree/master/program/object-detection-tf-py) for more details about the client program.

--- a/edge/object_detection/ssd_mobilenet/tf-py/README.md
+++ b/edge/object_detection/ssd_mobilenet/tf-py/README.md
@@ -3,13 +3,13 @@
 1. [Installation instructions](#installation)
 2. [Benchmarking instructions](#benchmarking)
 3. [Reference accuracy](#accuracy)
+4. [Further information](#further-info)
+
 
 <a name="installation"></a>
 ## Installation instructions
 
 Please follow the common [installation instructions](../README.md#installation) first.
-
-**NB:** See [`ck-tensorflow:program:object-detection-tf-py`](https://github.com/ctuning/ck-tensorflow/tree/master/program/object-detection-tf-py) for more details about the client program.
 
 ### Install TensorFlow (Python)
 
@@ -228,3 +228,15 @@ mAP: 0.23594222525632427
 Recall: 0.26864982712779556
 --------------------------------
 ```
+
+
+<a name="further-info"></a>
+## Further information
+
+### Using Collective Knowledge
+See the [common MobileNet instructions](../../../object_classification/mobilenets/README.md) for information on how to use Collective Knowledge
+to learn about [the anatomy of a benchmark](../../../object_clasification/mobilenets/README.md#anatomy), or
+to inspect and visualize [experimental results](../../../object_clasification/mobilenets/README.md#results).
+
+### Using the client program
+See [`ck-tensorflow:program:object-detection-tf-py`](https://github.com/ctuning/ck-tensorflow/tree/master/program/object-detection-tf-py) for more details about the client program.

--- a/edge/object_detection/ssd_mobilenet/tflite/README.md
+++ b/edge/object_detection/ssd_mobilenet/tflite/README.md
@@ -3,13 +3,13 @@
 1. [Installation instructions](#installation)
 2. [Benchmarking instructions](#benchmarking)
 3. [Reference accuracy](#accuracy)
+4. [Further information](#further-info)
+
 
 <a name="installation"></a>
 ## Installation instructions
 
 Please follow the common [installation instructions](../README.md#installation) first.
-
-**NB:** See [`ck-tensorflow:program:object-detection-tflite`](https://github.com/ctuning/ck-tensorflow/tree/master/program/object-detection-tflite) for more details about the client program.
 
 ### Install TensorFlow Lite (TFLite)
 
@@ -174,3 +174,15 @@ The TF version uses a frozen graph with `score_threshold=0.3`. However, the
 TFLite version has been converted from a checkpoint which
 [potentially](https://github.com/tensorflow/models/blob/e08b628663df7d2f2f6040fa3d4439ce4a3de33e/research/object_detection/samples/configs/ssd_mobilenet_v1_coco.config#L130)
 uses `score_threshold=1e-8`.
+
+
+<a name="further-info"></a>
+## Further information
+
+### Using Collective Knowledge
+See the [common MobileNet instructions](../../../object_classification/mobilenets/README.md) for information on how to use Collective Knowledge
+to learn about [the anatomy of a benchmark](../../../object_clasification/mobilenets/README.md#anatomy), or
+to inspect and visualize [experimental results](../../../object_clasification/mobilenets/README.md#results).
+
+### Using the client program
+See [`ck-tensorflow:program:object-detection-tflite`](https://github.com/ctuning/ck-tensorflow/tree/master/program/object-detection-tflite) for more details about the client program.

--- a/edge/object_detection/ssd_mobilenet/tflite/README.md
+++ b/edge/object_detection/ssd_mobilenet/tflite/README.md
@@ -140,21 +140,21 @@ creating index...
 index created!
 Running per image evaluation...
 Evaluate annotation type *bbox*
-DONE (t=11.23s).
+DONE (t=12.81s).
 Accumulating evaluation results...
-DONE (t=1.97s).
- Average Precision  (AP) @[ IoU=0.50:0.95 | area=   all | maxDets=100 ] = 0.212
- Average Precision  (AP) @[ IoU=0.50      | area=   all | maxDets=100 ] = 0.320
- Average Precision  (AP) @[ IoU=0.75      | area=   all | maxDets=100 ] = 0.235
- Average Precision  (AP) @[ IoU=0.50:0.95 | area= small | maxDets=100 ] = 0.014
- Average Precision  (AP) @[ IoU=0.50:0.95 | area=medium | maxDets=100 ] = 0.152
- Average Precision  (AP) @[ IoU=0.50:0.95 | area= large | maxDets=100 ] = 0.490
- Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets=  1 ] = 0.196
- Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets= 10 ] = 0.243
- Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets=100 ] = 0.243
- Average Recall     (AR) @[ IoU=0.50:0.95 | area= small | maxDets=100 ] = 0.017
- Average Recall     (AR) @[ IoU=0.50:0.95 | area=medium | maxDets=100 ] = 0.172
- Average Recall     (AR) @[ IoU=0.50:0.95 | area= large | maxDets=100 ] = 0.570
+DONE (t=2.10s).
+ Average Precision  (AP) @[ IoU=0.50:0.95 | area=   all | maxDets=100 ] = 0.223
+ Average Precision  (AP) @[ IoU=0.50      | area=   all | maxDets=100 ] = 0.341
+ Average Precision  (AP) @[ IoU=0.75      | area=   all | maxDets=100 ] = 0.247
+ Average Precision  (AP) @[ IoU=0.50:0.95 | area= small | maxDets=100 ] = 0.015
+ Average Precision  (AP) @[ IoU=0.50:0.95 | area=medium | maxDets=100 ] = 0.160
+ Average Precision  (AP) @[ IoU=0.50:0.95 | area= large | maxDets=100 ] = 0.515
+ Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets=  1 ] = 0.203
+ Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets= 10 ] = 0.255
+ Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets=100 ] = 0.255
+ Average Recall     (AR) @[ IoU=0.50:0.95 | area= small | maxDets=100 ] = 0.019
+ Average Recall     (AR) @[ IoU=0.50:0.95 | area=medium | maxDets=100 ] = 0.182
+ Average Recall     (AR) @[ IoU=0.50:0.95 | area= large | maxDets=100 ] = 0.593
 
 Summary:
 -------------------------------
@@ -162,18 +162,13 @@ Graph loaded in 0.000000s
 All images loaded in 0.000000s
 All images detected in 0.000000s
 Average detection time: 0.000000s
-mAP: 0.2119855643254357
-Recall: 0.24317820057128117
+mAP: 0.22349680978666922
+Recall: 0.2550505369422975
 --------------------------------
 ```
 **NB:** We are working on resolving the difference in mAP between the TF and
-TFLite versions (23.1% vs. 21.2%), as well as resolving the timing issue (all
-zeros).
-
-The TF version uses a frozen graph with `score_threshold=0.3`. However, the
-TFLite version has been converted from a checkpoint which
-[potentially](https://github.com/tensorflow/models/blob/e08b628663df7d2f2f6040fa3d4439ce4a3de33e/research/object_detection/samples/configs/ssd_mobilenet_v1_coco.config#L130)
-uses `score_threshold=1e-8`.
+TFLite versions (23.11% vs. 22.35%), as well as resolving the timing issue (all
+zeros). Both versions [use the same parameters](https://github.com/ctuning/ck-mlperf/blob/master/package/model-tflite-mlperf-ssd-mobilenet/README.md): `score_threshold=0.3`, etc.
 
 
 <a name="further-info"></a>

--- a/edge/object_detection/ssd_mobilenet/tflite/README.md
+++ b/edge/object_detection/ssd_mobilenet/tflite/README.md
@@ -181,8 +181,8 @@ uses `score_threshold=1e-8`.
 
 ### Using Collective Knowledge
 See the [common MobileNet instructions](../../../object_classification/mobilenets/README.md) for information on how to use Collective Knowledge
-to learn about [the anatomy of a benchmark](../../../object_clasification/mobilenets/README.md#anatomy), or
-to inspect and visualize [experimental results](../../../object_clasification/mobilenets/README.md#results).
+to learn about [the anatomy of a benchmark](../../../object_clasification/mobilenets/README.md#the-anatomy-of-a-benchmark), or
+to inspect and visualize [experimental results](../../../object_clasification/mobilenets/README.md#inspecting-recorded-experimental-results).
 
 ### Using the client program
 See [`ck-tensorflow:program:object-detection-tflite`](https://github.com/ctuning/ck-tensorflow/tree/master/program/object-detection-tflite) for more details about the client program.


### PR DESCRIPTION
- Update TFLite accuracy (22.35% from 21.20%).
- Fix package installation by tags.
- Fix an issue with functionality used before being enabled by Git pull.
- Recommend to use static TF 1.13.1 for Android again after fixing a linking issue.
- Enumerate options for installing Python packages so it's clear that only one of them should be used.

