### PR TITLE
LoadGen: Add several early outs in performance mode.

### DIFF
--- a/loadgen/demos/py_demo_single_stream.py
+++ b/loadgen/demos/py_demo_single_stream.py
@@ -45,7 +45,7 @@ def main(argv):
     settings = mlperf_loadgen.TestSettings()
     settings.scenario = mlperf_loadgen.TestScenario.SingleStream
     settings.mode = mlperf_loadgen.TestMode.PerformanceOnly
-    settings.single_stream_expected_qps = 100
+    settings.single_stream_expected_latency_ns = 1000000;
     settings.enable_spec_overrides = True
     settings.override_target_latency_ns = 100000000
     settings.override_min_query_count = 100

--- a/loadgen/test_settings_internal.h
+++ b/loadgen/test_settings_internal.h
@@ -27,7 +27,7 @@ struct TestSettingsInternal {
   std::chrono::milliseconds min_duration{60000};
   std::chrono::milliseconds max_duration{0};
   uint64_t min_query_count;
-  uint64_t max_query_count = 0;
+  uint64_t max_query_count = std::numeric_limits<uint64_t>::max();
 
   uint64_t qsl_rng_seed = kDefaultQslSeed;
   uint64_t sample_index_rng_seed = kDefaultSampleSeed;


### PR DESCRIPTION
* Enforces bounds of requested query counts and test duration.
* Log an error if we run out of pre-generated queries to
  issue before the minimum thresholds are met.
* Tracks outstanding queries and detects if the SUT falls too
  far behind.
* Fix py_demo_single_stream.py.