### PR TITLE
LoadGen: Fix for python bindings.

### DIFF
--- a/loadgen/bindings/python_api.cc
+++ b/loadgen/bindings/python_api.cc
@@ -8,7 +8,6 @@
 #include "../query_sample_library.h"
 #include "../system_under_test.h"
 #include "../test_settings.h"
-#include "pybind11/cast.h"
 #include "pybind11/functional.h"
 #include "pybind11/pybind11.h"
 #include "pybind11/stl.h"

--- a/loadgen/setup.py
+++ b/loadgen/setup.py
@@ -37,23 +37,21 @@ lib_sources = [
   "logging.cc",
 ]
 
+lib_bindings = [
+  "bindings/python_api.cc",
+]
+
 mlperf_loadgen_headers = public_headers + lib_headers
-mlperf_loadgen_sources_no_gen = lib_sources
+mlperf_loadgen_sources_no_gen = lib_sources + lib_bindings
 mlperf_loadgen_sources = \
     mlperf_loadgen_sources_no_gen + [generated_version_source_filename]
 
-sources = [
-    "bindings/python_api.cc",
-    "generated/version.cc",
-    "loadgen.cc",
-    "logging.cc",
-]
 
 mlperf_loadgen_module = Extension('mlperf_loadgen',
                     define_macros = [('MAJOR_VERSION', '0'),
                                      ('MINOR_VERSION', '5')],
                     include_dirs = [ '.', '../third_party/pybind/include' ],
-                    sources = mlperf_loadgen_sources + sources,
+                    sources = mlperf_loadgen_sources,
                     depends = mlperf_loadgen_headers)
 
 setup (name = 'mlperf_loadgen',


### PR DESCRIPTION
Fixes setup.py.

Removes unnecessary include in bindings that were triggering a ton
of compiler warnings.