### PR TITLE
LoadGen: Implement the offline scenario.

### DIFF
--- a/loadgen/bindings/python_api.cc
+++ b/loadgen/bindings/python_api.cc
@@ -174,8 +174,8 @@ PYBIND11_MODULE(mlperf_loadgen, m) {
       .def_readwrite("multi_stream_samples_per_query",
                      &TestSettings::multi_stream_samples_per_query)
       .def_readwrite("server_target_qps", &TestSettings::server_target_qps)
-      .def_readwrite("server_coallesce_queries",
-                     &TestSettings::server_coallesce_queries)
+      .def_readwrite("server_coalesce_queries",
+                     &TestSettings::server_coalesce_queries)
       .def_readwrite("offline_expected_qps",
                      &TestSettings::offline_expected_qps)
       .def_readwrite("enable_spec_overrides",

--- a/loadgen/demos/BUILD.gn
+++ b/loadgen/demos/BUILD.gn
@@ -5,6 +5,7 @@ executable("loadgen_demo_cpp") {
 
 source_set("loadgen_demos_python") {
   sources = [ "py_demo_multi_stream.py",
+              "py_demo_offline.py",
               "py_demo_server.py",
               "py_demo_single_stream.py" ]
   deps = [ "../..:loadgen_pymodule_wheel_lib" ]

--- a/loadgen/test_settings.h
+++ b/loadgen/test_settings.h
@@ -78,9 +78,13 @@ struct TestSettings {
   // |server_target_qps| is only used as a hint in SearchForPeakPerformance
   // mode.
   double server_target_qps = 10;
-  bool server_coallesce_queries = false;  // TODO: Use this.
+  bool server_coalesce_queries = false;  // TODO: Use this.
 
   // Offline-specific settings.
+  // Used to specify the qps the SUT expects to hit for the offline load.
+  // In the offline scenario, all queries will be coalesced into a single
+  // query; in this sense, "samples per second" is equivalent to "queries per
+  // second." We go with QPS for consistency.
   double offline_expected_qps = 10;
 
   // |enable_spec_overrides| is useful for experimentation and


### PR DESCRIPTION
* Coallesces all queries into a single one.
* GenerateQueries can produce zero duration queries for offline.
* Adds py_demo_offline.py.
* Updates ResponseDelegate so it:
  * Doesn't trace samples for the offline scenario.
    Doing so wasn't visually helpful since all the samples overlap.
  * Only copies data in Accuracy mode.
  * Only tracks oustanding queries in the Server scenario.
* Renames RunVerificationMode to RunAccuracyMode.
* Fixes spelling of coalesce everywhere.