### PR TITLE
Add root_model_dir to FAI-PEP arguments as it is newly added requirement

### DIFF
--- a/edge/object_classification/shufflenet/caffe2/run.sh
+++ b/edge/object_classification/shufflenet/caffe2/run.sh
@@ -61,6 +61,7 @@ echo "
   \"--remote_repository\": \"origin\",
   \"--repo\": \"git\",
   \"--repo_dir\": \"${REPO_DIR}\",
+  \"--root_model_dir\": \"${CONFIG_DIR}/root_model_dir\",
   \"--screen_reporter\": null
 }
 " > ${CONFIG_DIR}/config.txt

--- a/edge/object_segmentation/maskrcnn2go/run.sh
+++ b/edge/object_segmentation/maskrcnn2go/run.sh
@@ -60,6 +60,7 @@ echo "
   \"--remote_repository\": \"origin\",
   \"--repo\": \"git\",
   \"--repo_dir\": \"${REPO_DIR}\",
+  \"--root_model_dir\": \"${CONFIG_DIR}/root_model_dir\",
   \"--screen_reporter\": null
 }
 " > ${CONFIG_DIR}/config.txt


### PR DESCRIPTION
FAI-PEP requires this new argument to be specified. Add it to the script. 