### PR TITLE
Revert "LoadGen: Model-specific and scenario-specific qps and latency…

### DIFF
--- a/loadgen/bindings/python_api.cc
+++ b/loadgen/bindings/python_api.cc
@@ -153,14 +153,6 @@ void QuerySamplesComplete(std::vector<QuerySampleResponse> responses) {
 PYBIND11_MODULE(mlperf_loadgen, m) {
   m.doc() = "MLPerf Inference load generator.";
 
-  pybind11::enum_<TestModel>(m, "TestModel")
-      .value("Other", TestModel::Other)
-      .value("MobileNet", TestModel::MobileNet)
-      .value("ResNet", TestModel::ResNet)
-      .value("SsdSmall", TestModel::SsdSmall)
-      .value("SsdLarge", TestModel::SsdLarge)
-      .value("NMT", TestModel::NMT);
-
   pybind11::enum_<TestScenario>(m, "TestScenario")
       .value("SingleStream", TestScenario::SingleStream)
       .value("MultiStream", TestScenario::MultiStream)
@@ -175,7 +167,6 @@ PYBIND11_MODULE(mlperf_loadgen, m) {
 
   pybind11::class_<TestSettings>(m, "TestSettings")
       .def(pybind11::init<>())
-      .def_readwrite("model", &TestSettings::model)
       .def_readwrite("scenario", &TestSettings::scenario)
       .def_readwrite("mode", &TestSettings::mode)
       .def_readwrite("single_stream_expected_latency_ns",
@@ -189,12 +180,8 @@ PYBIND11_MODULE(mlperf_loadgen, m) {
                      &TestSettings::offline_expected_qps)
       .def_readwrite("enable_spec_overrides",
                      &TestSettings::enable_spec_overrides)
-      .def_readwrite("override_multi_stream_qps",
-                     &TestSettings::override_multi_stream_qps)
-      .def_readwrite("override_multi_stream_target_latency_ns",
-                     &TestSettings::override_multi_stream_target_latency_ns)
-      .def_readwrite("override_server_target_latency_ns",
-                     &TestSettings::override_server_target_latency_ns)
+      .def_readwrite("override_target_latency_ns",
+                     &TestSettings::override_target_latency_ns)
       .def_readwrite("override_multi_stream_max_async_queries",
                      &TestSettings::override_multi_stream_max_async_queries)
       .def_readwrite("override_min_duration_ms",

--- a/loadgen/demos/py_demo_multi_stream.py
+++ b/loadgen/demos/py_demo_multi_stream.py
@@ -55,9 +55,8 @@ def main(argv):
     settings.mode = mlperf_loadgen.TestMode.PerformanceOnly
     settings.multi_stream_samples_per_query = 4
     settings.enable_spec_overrides = True
-    settings.override_multi_stream_qps = 60
-    settings.override_multi_stream_target_latency_ns = 100000000
     settings.override_multi_stream_max_async_queries = 2
+    settings.override_target_latency_ns = 100000000
     settings.override_min_query_count = 100
     settings.override_min_duration_ms = 10000
 

--- a/loadgen/demos/py_demo_server.py
+++ b/loadgen/demos/py_demo_server.py
@@ -47,7 +47,7 @@ def main(argv):
     settings.mode = mlperf_loadgen.TestMode.PerformanceOnly
     settings.server_target_qps = 100
     settings.enable_spec_overrides = True
-    settings.override_server_target_latency_ns = 100000000
+    settings.override_target_latency_ns = 100000000
     settings.override_min_query_count = 100
     settings.override_min_duration_ms = 10000
 

--- a/loadgen/mlperf_spec_constants.h
+++ b/loadgen/mlperf_spec_constants.h
@@ -14,20 +14,6 @@ constexpr double kMinPerformanceRunDurationSeconds = 60.0;
 
 constexpr double kMultiStreamTargetQPS = 60.0;
 
-// Units are seconds.
-constexpr double kMultiStreamTargetLatencyMobileNet = .05;
-constexpr double kMultiStreamTargetLatencyResNet = .05;
-constexpr double kMultiStreamTargetLatencySsdSmall = .05;
-constexpr double kMultiStreamTargetLatencySsdLarge = .05;
-constexpr double kMultiStreamTargetLatencyNMT = .1;
-
-// Units are seconds.
-constexpr double kServerTargetLatencyMobileNet = .05;
-constexpr double kServerTargetLatencyResNet = .05;
-constexpr double kServerTargetLatencySsdSmall = .05;
-constexpr double kServerTargetLatencySsdLarge = .05;
-constexpr double kServerTargetLatencyNMT = .1;
-
 }  // namespace mlperf
 
 #endif  // MLPERF_LOADGEN_MLPERF_SPEC_CONSTANTS_H

--- a/loadgen/test_settings.h
+++ b/loadgen/test_settings.h
@@ -10,17 +10,6 @@
 
 namespace mlperf {
 
-// TestModel is used for logging purposes and to select which spec defaults
-// to use.
-enum TestModel {
-  Other,
-  MobileNet,
-  ResNet,
-  SsdSmall,
-  SsdLarge,
-  NMT,
-};
-
 enum TestScenario {
   // SingleStream issues queries containing a single sample. The next query is
   // only issued once the previous one has completed. Internal LoadGen latency
@@ -74,7 +63,6 @@ enum TestMode {
 
 // TODO: Logging settings. e.g.: sync vs. async; log frequency;
 struct TestSettings {
-  TestModel model = TestModel::ResNet;
   TestScenario scenario = TestScenario::SingleStream;
   TestMode mode = TestMode::PerformanceOnly;
 
@@ -105,12 +93,8 @@ struct TestSettings {
   bool enable_spec_overrides = false;
 
   // Settings after this point only have an effect if
-  // |enable_spec_overrides| above is true.
-
-  double override_multi_stream_qps = 0;                  // 0: Use spec default.
-  uint64_t override_multi_stream_target_latency_ns = 0;  // 0: Use spec default.
-  uint64_t override_server_target_latency_ns = 0;        // 0: Use spec default.
-
+  // |enable_spec_overrides| is true.
+  uint64_t override_target_latency_ns = 0;  // 0: Use spec default.
   // TODO: Should this be an official setting?
   int override_multi_stream_max_async_queries = 0;  // 0: Use spec default.
 

--- a/loadgen/test_settings_internal.cc
+++ b/loadgen/test_settings_internal.cc
@@ -5,70 +5,14 @@
 
 namespace mlperf {
 
-namespace {
-// Automatically convert seconds as a double to chrono::duration type.
-template <typename T>
-void sec2dur(T *d, double s) {
-  std::chrono::duration_cast<T>(std::chrono::duration<double>(s));
-}
-
-}  // namespace
-
-void TestSettingsInternal::UpdateMultiStreamTargetLatency() {
-  switch (model) {
-    case TestModel::MobileNet:
-      sec2dur(&target_latency, kMultiStreamTargetLatencyMobileNet);
-      break;
-    case TestModel::ResNet:
-      sec2dur(&target_latency, kMultiStreamTargetLatencyResNet);
-      break;
-    case TestModel::SsdSmall:
-      sec2dur(&target_latency, kMultiStreamTargetLatencySsdSmall);
-      break;
-    case TestModel::SsdLarge:
-      sec2dur(&target_latency, kMultiStreamTargetLatencySsdLarge);
-      break;
-    case TestModel::NMT:
-      sec2dur(&target_latency, kMultiStreamTargetLatencyNMT);
-      break;
-    case TestModel::Other:
-      sec2dur(&target_latency, kMultiStreamTargetLatencyResNet);
-      break;
-  }
-}
-
-void TestSettingsInternal::UpdateServerTargetLatency() {
-  switch (model) {
-    case TestModel::MobileNet:
-      sec2dur(&target_latency, kServerTargetLatencyMobileNet);
-      break;
-    case TestModel::ResNet:
-      sec2dur(&target_latency, kServerTargetLatencyResNet);
-      break;
-    case TestModel::SsdSmall:
-      sec2dur(&target_latency, kServerTargetLatencySsdSmall);
-      break;
-    case TestModel::SsdLarge:
-      sec2dur(&target_latency, kServerTargetLatencySsdLarge);
-      break;
-    case TestModel::NMT:
-      sec2dur(&target_latency, kServerTargetLatencyNMT);
-      break;
-    case TestModel::Other:
-      sec2dur(&target_latency, kServerTargetLatencyResNet);
-      break;
-  }
-}
-
 TestSettingsInternal::TestSettingsInternal(
     const TestSettings &requested_settings)
     : requested(requested_settings),
-      model(requested.model),
       scenario(requested.scenario),
       mode(requested.mode),
       samples_per_query(1),
       target_qps(60.0),
-      target_latency(0),
+      target_latency(std::nano::den),
       max_async_queries(2),
       min_duration(std::milli::den),
       max_duration(0),
@@ -79,15 +23,14 @@ TestSettingsInternal::TestSettingsInternal(
       qsl_rng_seed(kDefaultQslSeed),
       sample_index_rng_seed(kDefaultSampleSeed),
       schedule_rng_seed(kDefaultScheduleSeed) {
-  // Target QPS and latency.
-  switch (scenario) {
+  // Target QPS.
+  switch (requested.scenario) {
     case TestScenario::SingleStream:
       target_qps = static_cast<double>(std::nano::den) /
                    requested.single_stream_expected_latency_ns;
       break;
     case TestScenario::MultiStream:
       target_qps = kMultiStreamTargetQPS;
-      UpdateMultiStreamTargetLatency();
       break;
     case TestScenario::Server:
       if (requested.server_target_qps >= 0.0) {
@@ -99,7 +42,6 @@ TestSettingsInternal::TestSettingsInternal(
                         "requested", server_target_qps, "using", target_qps);
         });
       }
-      UpdateServerTargetLatency();
       break;
     case TestScenario::Offline:
       if (requested.offline_expected_qps >= 0.0) {
@@ -115,12 +57,12 @@ TestSettingsInternal::TestSettingsInternal(
   }
 
   // Samples per query.
-  if (scenario == TestScenario::MultiStream) {
+  if (requested.scenario == TestScenario::MultiStream) {
     samples_per_query = requested.multi_stream_samples_per_query;
   }
 
   // In the offline scenario, coalesce all queries into a single query.
-  if (scenario == TestScenario::Offline) {
+  if (requested.scenario == TestScenario::Offline) {
     // TODO: Should the spec require a max duration for large query counts?
     // kSlack is used to make sure we generate enough samples for the SUT
     // to take longer than than the minimum test duration required by the
@@ -139,7 +81,7 @@ TestSettingsInternal::TestSettingsInternal(
   }
 
   // Do not allow overrides for a submission run.
-  if (mode == TestMode::SubmissionRun) {
+  if (requested.mode == TestMode::SubmissionRun) {
     LogError([](AsyncLog &log) {
       log.LogDetail(
           "Overriding defaults for a SubmissionRun not allowed. \
@@ -148,27 +90,21 @@ TestSettingsInternal::TestSettingsInternal(
     return;
   }
 
-  // Scenario-specific overrides.
-  switch (scenario) {
-    case TestScenario::SingleStream:
-      break;
-    case TestScenario::MultiStream:
-      if (requested.override_multi_stream_target_latency_ns != 0) {
-        target_latency = std::chrono::nanoseconds(
-            requested.override_multi_stream_target_latency_ns);
-      }
-      if (requested.override_multi_stream_max_async_queries != 0) {
-        max_async_queries = requested.override_multi_stream_max_async_queries;
-      }
-      break;
-    case TestScenario::Server:
-      if (requested.override_server_target_latency_ns != 0) {
-        target_latency = std::chrono::nanoseconds(
-            requested.override_server_target_latency_ns);
-      }
-      break;
-    case TestScenario::Offline:
-      break;
+  if (requested.override_target_latency_ns != 0) {
+    target_latency =
+        std::chrono::nanoseconds(requested.override_target_latency_ns);
+  }
+
+  if (requested.override_multi_stream_max_async_queries != 0) {
+    if (requested.scenario == TestScenario::MultiStream) {
+      max_async_queries = requested.override_multi_stream_max_async_queries;
+    } else {
+      LogError([](AsyncLog &log) {
+        log.LogDetail(
+            "Overriding max async queries outside of the \
+                       MultiStream scenario has no effect.");
+      });
+    }
   }
 
   // Test duration.
@@ -197,25 +133,6 @@ TestSettingsInternal::TestSettingsInternal(
   if (requested.override_schedule_rng_seed != 0) {
     schedule_rng_seed = requested.override_schedule_rng_seed;
   }
-}
-
-std::string ToString(TestModel model) {
-  switch (model) {
-    case TestModel::MobileNet:
-      return "MobileNet";
-    case TestModel::ResNet:
-      return "ResNet";
-    case TestModel::SsdSmall:
-      return "SsdSmall";
-    case TestModel::SsdLarge:
-      return "SsdLarge";
-    case TestModel::NMT:
-      return "NMT";
-    case TestModel::Other:
-      return "Other";
-  }
-  assert(false);
-  return "InvalidModel";
 }
 
 std::string ToString(TestScenario scenario) {
@@ -252,7 +169,6 @@ void LogRequestedTestSettings(const TestSettings &s) {
   LogDetail([s](AsyncLog &log) {
     log.LogDetail("");
     log.LogDetail("Requested Settings:");
-    log.LogDetail("Model : " + ToString(s.model));
     log.LogDetail("Scenario : " + ToString(s.scenario));
     log.LogDetail("Test mode : " + ToString(s.mode));
 
@@ -276,11 +192,8 @@ void LogRequestedTestSettings(const TestSettings &s) {
 
     // Overrides
     log.LogDetail("enable_spec_overrides : ", s.enable_spec_overrides);
-    log.LogDetail("override_multi_stream_qps : ", s.override_multi_stream_qps);
-    log.LogDetail("override_multi_stream_target_latency_ns : ",
-                  s.override_multi_stream_target_latency_ns);
-    log.LogDetail("override_server_target_latency_ns : ",
-                  s.override_server_target_latency_ns);
+    log.LogDetail("override_target_latency_ns : ",
+                  s.override_target_latency_ns);
     log.LogDetail("override_multi_stream_max_async_queries : ",
                   s.override_multi_stream_max_async_queries);
     log.LogDetail("override_min_duration_ms : ", s.override_min_duration_ms);
@@ -301,7 +214,6 @@ void TestSettingsInternal::LogSettings() {
     log.LogDetail("");
     log.LogDetail("Effective Settings:");
 
-    log.LogDetail("Model : " + ToString(s.model));
     log.LogDetail("Scenario : " + ToString(s.scenario));
     log.LogDetail("Test mode : " + ToString(s.mode));
 

--- a/loadgen/test_settings_internal.h
+++ b/loadgen/test_settings_internal.h
@@ -15,7 +15,6 @@ struct TestSettingsInternal {
   void LogSettings();
 
   const TestSettings requested;
-  const TestModel model;        // Copied here for convenience.
   const TestScenario scenario;  // Copied here for convenience.
   const TestMode mode;          // Copied here for convenience.
 
@@ -32,10 +31,6 @@ struct TestSettingsInternal {
   uint64_t qsl_rng_seed;
   uint64_t sample_index_rng_seed;
   uint64_t schedule_rng_seed;
-
- private:
-  void UpdateMultiStreamTargetLatency();
-  void UpdateServerTargetLatency();
 };
 
 }  // namespace mlperf


### PR DESCRIPTION
… targets."

This reverts commit 8d4c2d7b0b7e7c6e1c9e2ebdf42bb5867be6babd.

Need some more discussion regarding whether the loadgen
should be model-aware.