### PR TITLE
LoadGen: Add TestScenario::MultiStreamFree

### DIFF
--- a/loadgen/bindings/python_api.cc
+++ b/loadgen/bindings/python_api.cc
@@ -156,6 +156,7 @@ PYBIND11_MODULE(mlperf_loadgen, m) {
   pybind11::enum_<TestScenario>(m, "TestScenario")
       .value("SingleStream", TestScenario::SingleStream)
       .value("MultiStream", TestScenario::MultiStream)
+      .value("MultiStreamFree", TestScenario::MultiStreamFree)
       .value("Server", TestScenario::Server)
       .value("Offline", TestScenario::Offline);
 

--- a/loadgen/demos/BUILD.gn
+++ b/loadgen/demos/BUILD.gn
@@ -5,6 +5,7 @@ executable("loadgen_demo_cpp") {
 
 source_set("loadgen_demos_python") {
   sources = [ "py_demo_multi_stream.py",
+              "py_demo_multi_stream_free.py",
               "py_demo_offline.py",
               "py_demo_server.py",
               "py_demo_single_stream.py" ]

--- a/loadgen/demos/py_demo_multi_stream_free.py
+++ b/loadgen/demos/py_demo_multi_stream_free.py
@@ -1,0 +1,72 @@
+"""
+Python demo showing how to use the MLPerf Inference load generator bindings.
+"""
+
+from __future__ import print_function
+from absl import app
+import mlperf_loadgen
+import threading
+import time
+import numpy
+
+
+def load_samples_to_ram(query_samples):
+    return
+
+
+def unload_samples_from_ram(query_samples):
+    return
+
+
+# Processes queries in 3 slices that complete at different times.
+def process_query_async(query_samples, i_slice):
+    time.sleep(.001 * (i_slice + 1))
+    responses = []
+    samples_to_complete = query_samples[i_slice:len(query_samples):3]
+    for s in samples_to_complete:
+        responses.append(mlperf_loadgen.QuerySampleResponse(s.id, 0, 0))
+    mlperf_loadgen.QuerySamplesComplete(responses)
+
+
+def issue_query(query_samples):
+    threading.Thread(
+            target=process_query_async,
+            args=(query_samples, 0)).start()
+    threading.Thread(
+            target=process_query_async,
+            args=(query_samples, 1)).start()
+    threading.Thread(
+            target=process_query_async,
+            args=(query_samples, 2)).start()
+
+
+def process_latencies(latencies_ns):
+    print("Average latency: ")
+    print(numpy.mean(latencies_ns))
+    print("Median latency: ")
+    print(numpy.percentile(latencies_ns, 50))
+    print("90 percentile latency: ")
+    print(numpy.percentile(latencies_ns, 90))
+
+
+def main(argv):
+    settings = mlperf_loadgen.TestSettings()
+    settings.scenario = mlperf_loadgen.TestScenario.MultiStreamFree
+    settings.mode = mlperf_loadgen.TestMode.PerformanceOnly
+    settings.multi_stream_samples_per_query = 4
+    settings.enable_spec_overrides = True
+    settings.override_multi_stream_max_async_queries = 2
+    settings.override_target_latency_ns = 100000000
+    settings.override_min_query_count = 100
+    settings.override_min_duration_ms = 10000
+
+    sut = mlperf_loadgen.ConstructSUT(issue_query, process_latencies)
+    qsl = mlperf_loadgen.ConstructQSL(
+        1024, 128, load_samples_to_ram, unload_samples_from_ram)
+    mlperf_loadgen.StartTest(sut, qsl, settings)
+    mlperf_loadgen.DestroyQSL(qsl)
+    mlperf_loadgen.DestroySUT(sut)
+
+
+if __name__ == '__main__':
+    app.run(main)

--- a/loadgen/loadgen.cc
+++ b/loadgen/loadgen.cc
@@ -281,7 +281,8 @@ std::vector<QueryMetadata> GenerateQueries(
   uint64_t query_sequence_id = 0;
   uint64_t sample_sequence_id = 0;
   while (timestamp <= k2xTargetDuration || queries.size() < min_queries) {
-    if (scenario == TestScenario::MultiStream) {
+    if (scenario == TestScenario::MultiStream ||
+        scenario == TestScenario::MultiStreamFree) {
       QuerySampleIndex sample_i = sample_distribution(sample_rng);
       for (auto& s : samples) {
         // Select contiguous samples in the MultiStream scenario.
@@ -315,12 +316,10 @@ std::vector<QueryMetadata> GenerateQueries(
 // since each scenario has its own specialization.
 template <TestScenario scenario>
 struct QueryScheduler {
+  static_assert(scenario != scenario, "Unhandled TestScenario");
   QueryScheduler(const TestSettingsInternal& settings,
-                 const PerfClock::time_point) {
-    assert(false);
-  }
+                 const PerfClock::time_point) {}
   PerfClock::time_point Wait(QueryMetadata* next_query) {
-    assert(false);
     return PerfClock::now();
   }
 };
@@ -354,11 +353,62 @@ enum class MultiStreamFrequency { Fixed, Free };
 template <>
 struct QueryScheduler<TestScenario::MultiStream> {
   QueryScheduler(const TestSettingsInternal& settings,
-                 const PerfClock::time_point start,
-                 MultiStreamFrequency frequency = MultiStreamFrequency::Fixed)
-      : frequency(frequency),
+                 const PerfClock::time_point start)
+      : qps(settings.target_qps),
         max_async_queries(settings.max_async_queries),
-        tick_time(start) {}
+        start_time(start) {}
+
+  PerfClock::time_point Wait(QueryMetadata* next_query) {
+    {
+      prev_queries.push(next_query);
+      auto trace =
+          MakeScopedTracer([](AsyncLog& log) { log.ScopedTrace("Waiting"); });
+      if (prev_queries.size() > max_async_queries) {
+        prev_queries.front()->WaitForAllSamplesCompleted();
+        prev_queries.pop();
+      }
+    }
+
+    {
+      auto trace = MakeScopedTracer(
+          [](AsyncLog& log) { log.ScopedTrace("Scheduling"); });
+      // TODO(brianderson): Skip ticks based on the query complete time,
+      //     before the query snchronization + notification thread hop,
+      //     rather than after.
+      PerfClock::time_point now = PerfClock::now();
+      auto i_period_old = i_period;
+      PerfClock::time_point tick_time;
+      do {
+        i_period++;
+        tick_time =
+            start_time + SecondsToDuration<PerfClock::duration>(i_period / qps);
+        Log([tick_time](AsyncLog& log) {
+          log.TraceAsyncInstant("QueryInterval", 0, tick_time);
+        });
+      } while (tick_time < now);
+      next_query->scheduled_intervals = i_period - i_period_old;
+      next_query->scheduled_time = tick_time;
+      std::this_thread::sleep_until(tick_time);
+    }
+
+    auto now = PerfClock::now();
+    next_query->issued_start_time = now;
+    return now;
+  }
+
+  size_t i_period = 0;
+  double qps;
+  const size_t max_async_queries;
+  PerfClock::time_point start_time;
+  std::queue<QueryMetadata*> prev_queries;
+};
+
+// MultiStreamFree QueryScheduler
+template <>
+struct QueryScheduler<TestScenario::MultiStreamFree> {
+  QueryScheduler(const TestSettingsInternal& settings,
+                 const PerfClock::time_point start)
+      : max_async_queries(settings.max_async_queries) {}
 
   PerfClock::time_point Wait(QueryMetadata* next_query) {
     bool schedule_time_needed = true;
@@ -367,37 +417,11 @@ struct QueryScheduler<TestScenario::MultiStream> {
       auto trace =
           MakeScopedTracer([](AsyncLog& log) { log.ScopedTrace("Waiting"); });
       if (prev_queries.size() > max_async_queries) {
-        switch (frequency) {
-          case MultiStreamFrequency::Fixed:
-            prev_queries.front()->WaitForAllSamplesCompleted();
-            break;
-          case MultiStreamFrequency::Free:
-            next_query->scheduled_time =
-                prev_queries.front()->WaitForAllSamplesCompletedWithTimestamp();
-            schedule_time_needed = false;
-            break;
-        }
+        next_query->scheduled_time =
+            prev_queries.front()->WaitForAllSamplesCompletedWithTimestamp();
+        schedule_time_needed = false;
         prev_queries.pop();
       }
-    }
-
-    if (frequency == MultiStreamFrequency::Fixed) {
-      auto trace = MakeScopedTracer(
-          [](AsyncLog& log) { log.ScopedTrace("Scheduling"); });
-      // TODO(brianderson): Skip ticks based on the query complete time,
-      //     before the query snchronization + notification thread hop,
-      //     rather than after.
-      PerfClock::time_point now = PerfClock::now();
-      auto i_period_old = i_period;
-      do {
-        tick_time += kPeriods[i_period++ % 3];
-        Log([tick_time = tick_time](AsyncLog& log) {
-          log.TraceAsyncInstant("QueryInterval", 0, tick_time);
-        });
-      } while (tick_time < now);
-      next_query->scheduled_intervals = i_period - i_period_old;
-      next_query->scheduled_time = tick_time;
-      std::this_thread::sleep_until(tick_time);
     }
 
     auto now = PerfClock::now();
@@ -408,21 +432,9 @@ struct QueryScheduler<TestScenario::MultiStream> {
     return now;
   }
 
-  // TODO: Support frequencies other than 30Hz.
-  static constexpr std::chrono::nanoseconds kPeriods[] = {
-      std::chrono::nanoseconds(33333333),
-      std::chrono::nanoseconds(33333334),
-      std::chrono::nanoseconds(33333333),
-  };
-  const MultiStreamFrequency frequency;
   const size_t max_async_queries;
-  PerfClock::time_point tick_time;
-  size_t i_period = 0;
   std::queue<QueryMetadata*> prev_queries;
 };
-
-constexpr std::chrono::nanoseconds
-    QueryScheduler<TestScenario::MultiStream>::kPeriods[];
 
 // Server QueryScheduler
 template <>
@@ -665,6 +677,7 @@ bool PerformanceSummary::MinSamplesMet() {
 
 bool PerformanceSummary::HasPerfConstraints() {
   return settings.scenario == TestScenario::MultiStream ||
+         settings.scenario == TestScenario::MultiStreamFree ||
          settings.scenario == TestScenario::Server;
 }
 
@@ -672,7 +685,8 @@ bool PerformanceSummary::PerfConstraintsMet() {
   switch (settings.scenario) {
     case TestScenario::SingleStream:
       return true;
-    case TestScenario::MultiStream: {
+    case TestScenario::MultiStream:
+    case TestScenario::MultiStreamFree: {
       // TODO: Finalize multi-stream performance targets with working group.
       ProcessLatencies();
       return latency_target.value <= settings.target_latency.count();
@@ -705,7 +719,8 @@ void PerformanceSummary::Log(AsyncLog& log) {
       log.LogSummary("90th percentile latency (ns) : ", latency_target.value);
       break;
     }
-    case TestScenario::MultiStream: {
+    case TestScenario::MultiStream:
+    case TestScenario::MultiStreamFree: {
       log.LogSummary("Samples per query : ", settings.samples_per_query);
       break;
     }
@@ -773,7 +788,8 @@ void PerformanceSummary::Log(AsyncLog& log) {
   settings.LogSummary(log);
 }
 
-void LoadSamplesToRam(QuerySampleLibrary* qsl, const std::vector<QuerySampleIndex>& samples) {
+void LoadSamplesToRam(QuerySampleLibrary* qsl,
+                      const std::vector<QuerySampleIndex>& samples) {
   LogDetail([samples](AsyncLog& log) {
     std::string set("\"[");
     for (auto i : samples) {
@@ -886,6 +902,8 @@ struct RunFunctions {
         return GetCompileTime<TestScenario::SingleStream>();
       case TestScenario::MultiStream:
         return GetCompileTime<TestScenario::MultiStream>();
+      case TestScenario::MultiStreamFree:
+        return GetCompileTime<TestScenario::MultiStreamFree>();
       case TestScenario::Server:
         return GetCompileTime<TestScenario::Server>();
       case TestScenario::Offline:
@@ -928,9 +946,11 @@ std::vector<std::vector<QuerySampleIndex>> GenerateLoadableSets(
   }
 
   const size_t set_size = qsl->PerformanceSampleCount();
-  const size_t set_padding = settings.scenario == TestScenario::MultiStream
-                                 ? settings.samples_per_query - 1
-                                 : 0;
+  const size_t set_padding =
+      (settings.scenario == TestScenario::MultiStream ||
+       settings.scenario == TestScenario::MultiStreamFree)
+          ? settings.samples_per_query - 1
+          : 0;
   std::vector<QuerySampleIndex> loadable_set;
   loadable_set.reserve(set_size + set_padding);
   size_t remaining_count = samples.size();

--- a/loadgen/test_settings.h
+++ b/loadgen/test_settings.h
@@ -18,7 +18,7 @@ enum TestScenario {
   SingleStream,
 
   // MultiStream ideally issues queries containing N samples each at a uniform
-  // rate of 60 Hz. However, the loadgen will skip sending for one interval if
+  // rate of 20 Hz. However, the loadgen will skip sending for one interval if
   // the SUT falls behind too much. By default and spec, the loadgen will only
   // allow 1 outstanding query at a time.
   // TODO: Some SUTs may benefit from pipelining multiple queries while still
@@ -29,6 +29,16 @@ enum TestScenario {
   // Final performance result is PASS if the 90 percentile latency is under
   // a given threshold (model-specific) for a given N.
   MultiStream,
+
+  // MultiStreamFree is not an official MLPerf scenario, but is implemented
+  // for evaluation purposes.
+  // It is the same as MultiStream, but allows for up to P async queries where
+  // N is limited only by the latency target. Instead of attempting to issue
+  // queries at a fixed rate, this scenario issues a query as soon as the P'th
+  // oldest query completes.
+  // Final performance result is PASS if the 90th percentile latency is under
+  // a given threashold (model-specific) for a given value of N and P.
+  MultiStreamFree,
 
   // Server sends queries with a single sample. Queries have a random poisson
   // (non-uniform) arrival rate that, when averaged, hits the target QPS.

--- a/loadgen/test_settings_internal.cc
+++ b/loadgen/test_settings_internal.cc
@@ -36,6 +36,7 @@ TestSettingsInternal::TestSettingsInternal(
                    requested.single_stream_expected_latency_ns;
       break;
     case TestScenario::MultiStream:
+    case TestScenario::MultiStreamFree:
       target_qps = kMultiStreamTargetQPS;
       break;
     case TestScenario::Server:
@@ -63,7 +64,8 @@ TestSettingsInternal::TestSettingsInternal(
   }
 
   // Samples per query.
-  if (requested.scenario == TestScenario::MultiStream) {
+  if (requested.scenario == TestScenario::MultiStream ||
+      requested.scenario == TestScenario::MultiStreamFree) {
     samples_per_query = requested.multi_stream_samples_per_query;
   }
 
@@ -106,7 +108,8 @@ void TestSettingsInternal::ApplyOverrides() {
   }
 
   if (requested.override_multi_stream_max_async_queries != 0) {
-    if (requested.scenario == TestScenario::MultiStream) {
+    if (requested.scenario == TestScenario::MultiStream ||
+        requested.scenario == TestScenario::MultiStreamFree) {
       max_async_queries = requested.override_multi_stream_max_async_queries;
     } else {
       LogError([](AsyncLog &log) {
@@ -152,6 +155,8 @@ std::string ToString(TestScenario scenario) {
       return "Single Stream";
     case TestScenario::MultiStream:
       return "Multi Stream";
+    case TestScenario::MultiStreamFree:
+      return "Multi Stream Free";
     case TestScenario::Server:
       return "Server";
     case TestScenario::Offline:
@@ -190,6 +195,7 @@ void LogRequestedTestSettings(const TestSettings &s) {
                       s.single_stream_expected_latency_ns);
         break;
       case TestScenario::MultiStream:
+      case TestScenario::MultiStreamFree:
         log.LogDetail("multi_stream_samples_per_query : ",
                       s.multi_stream_samples_per_query);
         break;


### PR DESCRIPTION
This is an alternative to MultiStream that allows for
a free running query interval based on completion of
the N'th oldest query.

This is not an official scenario, but is implemented for
evaluation purposes. Compared to MultiStream, it 1) enables
and potentially rewards pipelining and 2) does not quantize
the performance result to a fixed frequency.

It is split out into a separate scenario to simplify
the code for the vanilla MultiStream scenario.