### PR TITLE
LoadGen: Improve version generator git check.

### DIFF
--- a/loadgen/version_generator.py
+++ b/loadgen/version_generator.py
@@ -75,7 +75,9 @@ def generate_loadgen_version_definitions(cc_filename, loadgen_root):
     file.write(func_def("BuildDateLocal", "\"" + dateTimeNowLocal + "\""))
     file.write(func_def("BuildDateUtc", "\"" + dateTimeNowUtc + "\""))
 
-    git_command = "git -C \"" + loadgen_root + "/../\" ";
+    git_dir = "--git-dir=\"" + loadgen_root + "/../.git\" "
+    git_work_tree = "--work-tree=\"" + loadgen_root + "/..\" "
+    git_command = "git " + git_dir + git_work_tree
     gitStatus = os.popen(git_command + "status")
     print gitStatus.read()
     is_git_repo = gitStatus.close() == None


### PR DESCRIPTION
updates the script to explicitly check whether loadgen is part
of a git repository in the same place that the mlperf inference
repository would have it, not just that it's part of any git
repository.

This would still have some false positives, but if someone
doesn't want their project's git commit subjects included
in those cases, we can update the scripts at that time. This
is unlikely to be an actual issue.