### PR TITLE
LoadGen: Attempt to fix atexit segfault.

### DIFF
--- a/loadgen/BUILD.gn
+++ b/loadgen/BUILD.gn
@@ -47,6 +47,7 @@ static_library("mlperf_loadgen") {
   sources = mlperf_loadgen_sources
   include_dirs = [ "." ]
   deps = [ ":generate_loadgen_version_header" ]
+  configs += [ "//build/config/compiler:exceptions" ]
 }
 
 executable("loadgen_demo") {


### PR DESCRIPTION
This is a work around to avoid crashes when the destructors
of thread_local variabls attempt to access the global Logger at exit.
If the loadgen library was loaded as a python module, the global
Logger might be destroyed and all function definitions unloaded before the
last thread_local variable that references it.

As a work around, this patch:
1) Makes the thread_local variables a standard library type that
  supports type erasure and is part of the ABI.
2) Re-assigns all the thread_local variables with complex destructors
  at the destruction of Logger to types that are part of the ABI.

This should result in the destructor only referring to code
and data that will not have been unloaded after python has
unloaded the loadgen module.