### PR TITLE
LoadGen: Simplify atexit segfault fix.

### DIFF
--- a/loadgen/BUILD.gn
+++ b/loadgen/BUILD.gn
@@ -47,7 +47,6 @@ static_library("mlperf_loadgen") {
   sources = mlperf_loadgen_sources
   include_dirs = [ "." ]
   deps = [ ":generate_loadgen_version_header" ]
-  configs += [ "//build/config/compiler:exceptions" ]
 }
 
 executable("loadgen_demo") {

--- a/loadgen/loadgen.cc
+++ b/loadgen/loadgen.cc
@@ -27,6 +27,7 @@ struct SampleMetadata;
 struct QueryMetadata;
 
 struct ResponseDelegate {
+  virtual ~ResponseDelegate() = default;
   virtual void SampleComplete(SampleMetadata*, QuerySampleResponse*,
                               PerfClock::time_point) = 0;
   virtual void QueryComplete() = 0;
@@ -339,11 +340,6 @@ std::vector<QueryMetadata> GenerateQueries(
 template <TestScenario scenario>
 struct QueryScheduler {
   static_assert(scenario != scenario, "Unhandled TestScenario");
-  QueryScheduler(const TestSettingsInternal& settings,
-                 const PerfClock::time_point) {}
-  PerfClock::time_point Wait(QueryMetadata* next_query) {
-    return PerfClock::now();
-  }
 };
 
 // SingleStream QueryScheduler

--- a/loadgen/logging.h
+++ b/loadgen/logging.h
@@ -13,7 +13,7 @@
 #include <mutex>
 #include <set>
 #include <thread>
-#include <unordered_map>
+#include <unordered_set>
 #include <vector>
 
 #include "query_sample.h"
@@ -426,8 +426,7 @@ class Logger {
   friend TlsLogger;
   friend TlsLoggerWrapper;
 
-  void RegisterTlsLogger(TlsLogger* tls_logger,
-                         std::function<void()> destroyer);
+  void RegisterTlsLogger(TlsLogger* tls_logger);
   void UnRegisterTlsLogger(std::unique_ptr<TlsLogger> tls_logger);
   void RequestSwapBuffers(TlsLogger* tls_logger);
   void CollectTlsLoggerStats(TlsLogger* tls_logger);
@@ -462,10 +461,7 @@ class Logger {
   bool keep_io_thread_alive_ = false;
 
   std::mutex tls_loggers_registerd_mutex_;
-  // |destroyer| is only used in cases where the global Logger is destroyed
-  // before the thread-local TlsLoggers. i.e.: With python modules or
-  // with detached threads.
-  std::unordered_map<TlsLogger*, std::function<void()>> tls_loggers_registerd_;
+  std::unordered_set<TlsLogger*> tls_loggers_registerd_;
 
   // Temporarily stores TlsLogger data for threads that have exited until
   // all their log entries have been processed.

--- a/loadgen/system_under_test.h
+++ b/loadgen/system_under_test.h
@@ -1,6 +1,7 @@
 #ifndef MLPERF_LOADGEN_SYSTEM_UNDER_TEST_H
 #define MLPERF_LOADGEN_SYSTEM_UNDER_TEST_H
 
+#include <string>
 #include <vector>
 
 #include "query_sample.h"

--- a/loadgen/test_settings_internal.h
+++ b/loadgen/test_settings_internal.h
@@ -31,7 +31,7 @@ struct TestSettingsInternal {
   std::chrono::nanoseconds target_latency;
   int max_async_queries;
 
-  // Taget duration is used to generate queries of a minimum duration before
+  // Target duration is used to generate queries of a minimum duration before
   // the test run.
   std::chrono::milliseconds target_duration;
 

--- a/loadgen/version.cc
+++ b/loadgen/version.cc
@@ -14,7 +14,7 @@ void LogLoadgenVersion() {
     log.LogDetail("git_commit_date  : " + LoadgenGitCommitDate());
     log.LogDetail("git_log :\n\n" + LoadgenGitLog() + "\n");
     log.LogDetail("git_status :\n\n" + LoadgenGitStatus() + "\n");
-    if (LoadgenGitStatus() != "" && LoadgenGitStatus() != "NA") {
+    if (!LoadgenGitStatus().empty() && LoadgenGitStatus() != "NA") {
       log.FlagError();
       log.LogDetail("Loadgen built with uncommitted changes!");
     }


### PR DESCRIPTION
This also seems to work without requiring exceptions to
be enabled.

There is a risk that std::unique_ptr<TlsLogger>'s destructor
gets unloaded along with the loadgen module, but it doesn't
seem to be an issue in practice. Either it's optimized away
or it's still valid for some reason.