### PR TITLE
LoadGen: Improve log prefix/suffix order; Fix multistream+performance.

### DIFF
--- a/loadgen/bindings/python_api.cc
+++ b/loadgen/bindings/python_api.cc
@@ -134,7 +134,8 @@ void DestroyQSL(uintptr_t qsl) {
   delete qsl_cast;
 }
 
-void StartTest(uintptr_t sut, uintptr_t qsl, mlperf::TestSettings test_settings) {
+void StartTest(uintptr_t sut, uintptr_t qsl,
+               mlperf::TestSettings test_settings) {
   pybind11::gil_scoped_release gil_releaser;
   SystemUnderTestTrampoline* sut_cast =
       reinterpret_cast<SystemUnderTestTrampoline*>(sut);
@@ -144,8 +145,9 @@ void StartTest(uintptr_t sut, uintptr_t qsl, mlperf::TestSettings test_settings)
   mlperf::StartTest(sut_cast, qsl_cast, test_settings, default_log_settings);
 }
 
-void StartTestWithLogSettings(uintptr_t sut, uintptr_t qsl, mlperf::TestSettings test_settings,
-               mlperf::LogSettings log_settings) {
+void StartTestWithLogSettings(uintptr_t sut, uintptr_t qsl,
+                              mlperf::TestSettings test_settings,
+                              mlperf::LogSettings log_settings) {
   pybind11::gil_scoped_release gil_releaser;
   SystemUnderTestTrampoline* sut_cast =
       reinterpret_cast<SystemUnderTestTrampoline*>(sut);

--- a/loadgen/loadgen.cc
+++ b/loadgen/loadgen.cc
@@ -1030,10 +1030,10 @@ struct LogOutputs {
     }
     const std::string& suffix = output_settings.suffix;
 
-    summary_out.open(prefix + "mlperf_log_summary" + suffix + ".txt");
-    detail_out.open(prefix + "mlperf_log_detail" + suffix + ".txt");
-    accuracy_out.open(prefix + "mlperf_log_accuracy" + suffix + ".json");
-    trace_out.open(prefix + "mlperf_trace" + suffix + ".json");
+    summary_out.open(prefix + "summary" + suffix + ".txt");
+    detail_out.open(prefix + "detail" + suffix + ".txt");
+    accuracy_out.open(prefix + "accuracy" + suffix + ".json");
+    trace_out.open(prefix + "trace" + suffix + ".json");
   }
 
   bool CheckOutputs() {

--- a/loadgen/test_settings.h
+++ b/loadgen/test_settings.h
@@ -7,6 +7,7 @@
 // The comments in this file are indicative of the loadgen implementation.
 
 #include <cstdint>
+#include <string>
 
 namespace mlperf {
 
@@ -145,11 +146,11 @@ struct LogOutputSettings {
   // By default, the loadgen outputs its log files to outdir and
   // modifies the filenames of its logs with a prefix and suffix.
   // Filenames will take the form:
-  // "<outdir>/<prefix><datetime>mlperf_log_summary<suffix>.txt"
+  // "<outdir>/<datetime><prefix>summary<suffix>.txt"
   std::string outdir = ".";
-  std::string prefix = "";
+  std::string prefix = "mlperf_log_";
   std::string suffix = "";
-  bool prefix_with_datetime = false;  // |prefix| comes before the datetime.
+  bool prefix_with_datetime = false;
   bool copy_detail_to_stdout = false;
   bool copy_summary_to_stdout = false;
 };


### PR DESCRIPTION
Change log naming to take the form:
"<outdir>/<datetime><prefix>summary<suffix>.txt"

If a client relies on default settings, this will not affect
log naming.

Hopefully no one relies on the non-default settings since the
log settings landed this morning.