### PR TITLE
LoadGen: Server null perftests hit 1500k QPS

### DIFF
--- a/loadgen/tests/perftests_null_sut.cc
+++ b/loadgen/tests/perftests_null_sut.cc
@@ -10,6 +10,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
+#include <future>
+
 #include "../loadgen.h"
 #include "../query_sample_library.h"
 #include "../system_under_test.h"
@@ -59,14 +61,147 @@ class QuerySampleLibraryNull : public mlperf::QuerySampleLibrary {
   std::string name_{"NullQSL"};
 };
 
-int main(int argc, char* argv[]) {
+void TestSingleStream() {
   SystemUnderTestNull null_sut;
   QuerySampleLibraryNull null_qsl;
 
-  mlperf::TestSettings test_settings;
   mlperf::LogSettings log_settings;
   log_settings.log_output.prefix_with_datetime = true;
 
-  mlperf::StartTest(&null_sut, &null_qsl, test_settings, log_settings);
+  mlperf::TestSettings ts;
+
+  mlperf::StartTest(&null_sut, &null_qsl, ts, log_settings);
+}
+
+class SystemUnderTestNullStdAsync : public mlperf::SystemUnderTest {
+ public:
+  SystemUnderTestNullStdAsync() {
+    futures_.reserve(1000000);
+  }
+  ~SystemUnderTestNullStdAsync() override = default;
+  const std::string& Name() const override { return name_; }
+  void IssueQuery(const std::vector<mlperf::QuerySample>& samples) override {
+    futures_.emplace_back(std::async(std::launch::async, [samples] {
+      std::vector<mlperf::QuerySampleResponse> responses;
+      responses.reserve(samples.size());
+      for (auto s : samples) {
+        responses.push_back({s.id, 0, 0});
+      }
+      mlperf::QuerySamplesComplete(responses.data(), responses.size());
+    }));
+  }
+  void ReportLatencyResults(
+      const std::vector<mlperf::QuerySampleLatency>& latencies_ns) override {}
+
+ private:
+  std::string name_{"NullStdAsync"};
+  std::vector<std::future<void>> futures_;
+};
+
+void TestServerStdAsync() {
+  SystemUnderTestNullStdAsync null_std_async_sut;
+  QuerySampleLibraryNull null_qsl;
+
+  mlperf::LogSettings log_settings;
+  log_settings.log_output.prefix_with_datetime = true;
+  log_settings.log_output.copy_summary_to_stdout = true;
+
+  mlperf::TestSettings ts;
+  ts.scenario = mlperf::TestScenario::Server;
+  ts.server_target_qps = 2000000;
+  ts.min_duration_ms = 100;
+
+  mlperf::StartTest(&null_std_async_sut, &null_qsl, ts, log_settings);
+}
+
+class SystemUnderTestNullPool : public mlperf::SystemUnderTest {
+ public:
+  SystemUnderTestNullPool() {
+    samples_.reserve(kReserveSampleSize);
+    next_poll_time_ = std::chrono::high_resolution_clock::now() + poll_period_;
+    for (size_t i = 0; i < thread_count_; i++) {
+      threads_.emplace_back(&SystemUnderTestNullPool::WorkerThread, this);
+    }
+  }
+
+  ~SystemUnderTestNullPool() override {
+    {
+      std::unique_lock<std::mutex> lock(mutex_);
+      keep_workers_alive_ = false;
+    }
+    cv_.notify_all();
+    for (auto& thread : threads_) {
+      thread.join();
+    }
+  }
+
+  const std::string& Name() const override { return name_; }
+
+  void IssueQuery(const std::vector<mlperf::QuerySample>& samples) override {
+    std::unique_lock<std::mutex> lock(mutex_);
+    samples_.insert(samples_.end(), samples.begin(), samples.end());
+  }
+
+  void ReportLatencyResults(
+      const std::vector<mlperf::QuerySampleLatency>& latencies_ns) override {}
+
+ private:
+  void WorkerThread() {
+    std::vector<mlperf::QuerySample> my_samples;
+    my_samples.reserve(kReserveSampleSize);
+    std::unique_lock<std::mutex> lock(mutex_);
+    while (keep_workers_alive_) {
+      next_poll_time_ += poll_period_;
+      auto my_wakeup_time = next_poll_time_;
+      cv_.wait_until(lock, my_wakeup_time, [&](){ return !keep_workers_alive_; });
+      my_samples.swap(samples_);
+      lock.unlock();
+
+      std::vector<mlperf::QuerySampleResponse> responses;
+      responses.reserve(my_samples.size());
+      for (auto s : my_samples) {
+        responses.push_back({s.id, 0, 0});
+      }
+      mlperf::QuerySamplesComplete(responses.data(), responses.size());
+
+      lock.lock();
+      my_samples.clear();
+    }
+  }
+
+  static constexpr size_t kReserveSampleSize = 1024 * 1024;
+  const std::string name_{"NullPool"};
+  const size_t thread_count_ = 4;
+  const std::chrono::milliseconds poll_period_{1};
+  std::chrono::high_resolution_clock::time_point next_poll_time_;
+
+  std::mutex mutex_;
+  std::condition_variable cv_;
+  bool keep_workers_alive_ = true;
+  std::vector<std::thread> threads_;
+
+  std::vector<mlperf::QuerySample> samples_;
+};
+
+void TestServerPool() {
+  SystemUnderTestNullPool null_pool;
+  QuerySampleLibraryNull null_qsl;
+
+  mlperf::LogSettings log_settings;
+  log_settings.log_output.prefix_with_datetime = true;
+  log_settings.log_output.copy_summary_to_stdout = true;
+
+  mlperf::TestSettings ts;
+  ts.scenario = mlperf::TestScenario::Server;
+  ts.server_target_qps = 2000000;
+  ts.min_duration_ms = 100;
+
+  mlperf::StartTest(&null_pool, &null_qsl, ts, log_settings);
+}
+
+int main(int argc, char* argv[]) {
+  TestSingleStream();
+  TestServerStdAsync();
+  TestServerPool();
   return 0;
 }


### PR DESCRIPTION
The TestServerPool perftest hits ~1500k QPS on my local machine
compared to ~500k QPS for the single stream scenario, indicating
good performance for concurrent calls to QuerySamplesComplete
from multiple threads.

TestServerPool runs a simple thread pool the loadgen submits work to.
Each thread in the pool polls for work in staggerred phases.
    
Also implemented is TestServerStdAsync, which uses naive calls to
std::async. It only hits ~30k QPS on my machine.