### PR TITLE
LoadGen: Sanity checks for latency recording.

### DIFF
--- a/loadgen/loadgen.cc
+++ b/loadgen/loadgen.cc
@@ -44,6 +44,7 @@ struct QueryMetadata;
 struct SequenceGen {
   uint64_t NextQueryId() { return query_id++; }
   uint64_t NextSampleId() { return sample_id++; }
+  uint64_t CurrentSampleId() { return sample_id; }
 
  private:
   uint64_t query_id = 0;
@@ -539,7 +540,7 @@ PerformanceResult IssueQueries(SystemUnderTest* sut,
                                const TestSettingsInternal& settings,
                                const LoadableSampleSet& loaded_sample_set,
                                SequenceGen* sequence_gen) {
-  GlobalLogger().RestartLatencyRecording();
+  GlobalLogger().RestartLatencyRecording(sequence_gen->CurrentSampleId());
   ResponseDelegateDetailed<scenario, mode> response_logger;
 
   std::vector<QueryMetadata> queries = GenerateQueries<scenario, mode>(

--- a/loadgen/tests/perftests_null_sut.cc
+++ b/loadgen/tests/perftests_null_sut.cc
@@ -75,9 +75,7 @@ void TestSingleStream() {
 
 class SystemUnderTestNullStdAsync : public mlperf::SystemUnderTest {
  public:
-  SystemUnderTestNullStdAsync() {
-    futures_.reserve(1000000);
-  }
+  SystemUnderTestNullStdAsync() { futures_.reserve(1000000); }
   ~SystemUnderTestNullStdAsync() override = default;
   const std::string& Name() const override { return name_; }
   void IssueQuery(const std::vector<mlperf::QuerySample>& samples) override {
@@ -153,7 +151,8 @@ class SystemUnderTestNullPool : public mlperf::SystemUnderTest {
     while (keep_workers_alive_) {
       next_poll_time_ += poll_period_;
       auto my_wakeup_time = next_poll_time_;
-      cv_.wait_until(lock, my_wakeup_time, [&](){ return !keep_workers_alive_; });
+      cv_.wait_until(lock, my_wakeup_time,
+                     [&]() { return !keep_workers_alive_; });
       my_samples.swap(samples_);
       lock.unlock();
 


### PR DESCRIPTION
Flag errors if samples are missing their latency
or if an attempt to complete a sample twice is made.