### PR TITLE
LoadGen: Trace latency over time in the server scenario.

### DIFF
--- a/loadgen/loadgen.cc
+++ b/loadgen/loadgen.cc
@@ -184,9 +184,6 @@ struct DurationGeneratorNs {
 
 // Right now, this is the only implementation of ResponseDelegate,
 // but more will be coming soon.
-// TODO: Versions that don't copy data.
-// TODO: Versions that have less detailed logs.
-// TODO: Versions that do a delayed notification.
 template <TestScenario scenario, TestMode mode>
 struct ResponseDelegateDetailed : public ResponseDelegate {
   std::atomic<size_t> queries_completed{0};
@@ -207,11 +204,17 @@ struct ResponseDelegateDetailed : public ResponseDelegate {
     Log([sample, complete_begin_time, sample_data_copy](AsyncLog& log) {
       QueryMetadata* query = sample->query_metadata;
       DurationGeneratorNs sched{query->scheduled_time};
-      // Disable tracing each sample in offline mode. Since thousands of
-      // samples could be overlapping when visualized, it's not very useful.
-      // TODO: Should we disable for cloud mode as well? Sufficiently
-      // out-of-order processing could have lots of overlap too.
-      if (scenario != TestScenario::Offline) {
+
+      if (scenario == TestScenario::Server) {
+        // Trace the server scenario as a stacked graph via counter events.
+        DurationGeneratorNs issued{query->issued_start_time};
+        log.TraceCounterEvent("Latency", query->scheduled_time, "issue_delay",
+                              sched.delta(query->issued_start_time),
+                              "issue_to_done",
+                              issued.delta(complete_begin_time));
+      } else if (scenario != TestScenario::Offline) {
+        // Disable tracing of each sample in offline mode, where visualizing
+        // all samples overlapping isn't practical.
         log.TraceSample("Sample", sample->sequence_id, query->scheduled_time,
                         complete_begin_time, "sample_seq", sample->sequence_id,
                         "query_seq", query->sequence_id, "sample_idx",

--- a/loadgen/logging.h
+++ b/loadgen/logging.h
@@ -300,6 +300,21 @@ class AsyncLog {
                 << "\"ts\": " << (end - trace_origin_).count() << " },\n";
   }
 
+  template <typename... Args>
+  void TraceCounterEvent(const std::string& trace_name,
+                         PerfClock::time_point time, const Args... args) {
+    std::unique_lock<std::mutex> lock(trace_mutex_);
+    if (!trace_out_) {
+      return;
+    }
+    *trace_out_ << "{\"name\": \"" << trace_name << "\", "
+                << "\"ph\": \"C\", " << *current_pid_tid_
+                << "\"ts\": " << (time - trace_origin_).count() << ", "
+                << "\"args\": { ";
+    LogArgs(trace_out_, args...);
+    *trace_out_ << " }},\n";
+  }
+
   void RecordLatency(uint64_t sample_sequence_id, QuerySampleLatency latency);
   void RestartLatencyRecording(uint64_t first_sample_sequence_id);
   std::vector<QuerySampleLatency> GetLatenciesBlocking(size_t expected_count);


### PR DESCRIPTION
This disables the default horizontal per-sample trace and
replaces it with a stacked graph that visualizes the
issue delay and processing time over time.