### PR TITLE
[fix] fix accuracy gap in v0.5/classification_and_detection

### DIFF
--- a/v0.5/classification_and_detection/python/dataset.py
+++ b/v0.5/classification_and_detection/python/dataset.py
@@ -157,10 +157,10 @@ def resize_with_aspectratio(img, out_height, out_width, scale=87.5):
     new_width = int(100. * out_width / scale)
     if height > width:
         w = new_width
-        h = int(out_height * width / new_width)
+        h = int(new_height * height / width)
     else:
         h = new_height
-        w = int(out_width * height / new_height)
+        w = int(new_width * width / height)
     img = img.resize((w, h), Image.BILINEAR)
     return img
 


### PR DESCRIPTION
  1. problem comes from the way preprocessing the image size in this function: resize_with_aspectratio, resonable way is to resize the shorter side of the image to a bound size(in this case it's 256) while keeping the aspect ratio between the shorter and the longer side of the raw image. This will improve resnet50 and mobilenet accuracy to its target value.