### PR TITLE
Loadgen fix tests

### DIFF
--- a/loadgen/demos/py_demo_multi_stream.py
+++ b/loadgen/demos/py_demo_multi_stream.py
@@ -71,7 +71,7 @@ def main(argv):
     settings = mlperf_loadgen.TestSettings()
     settings.scenario = mlperf_loadgen.TestScenario.MultiStream
     settings.mode = mlperf_loadgen.TestMode.PerformanceOnly
-    settings.target_latency_ns = 100000000
+    settings.multi_stream_target_latency_ns = 100000000
     settings.multi_stream_samples_per_query = 4
     settings.multi_stream_max_async_queries = 2
     settings.min_query_count = 100

--- a/loadgen/demos/py_demo_multi_stream_free.py
+++ b/loadgen/demos/py_demo_multi_stream_free.py
@@ -71,8 +71,8 @@ def main(argv):
     settings = mlperf_loadgen.TestSettings()
     settings.scenario = mlperf_loadgen.TestScenario.MultiStreamFree
     settings.mode = mlperf_loadgen.TestMode.PerformanceOnly
+    settings.multi_stream_target_latency_ns = 100000000
     settings.multi_stream_samples_per_query = 4
-    settings.target_latency_ns = 100000000
     settings.multi_stream_max_async_queries = 2
     settings.min_query_count = 100
     settings.min_duration_ms = 10000

--- a/loadgen/tests/perftests_null_sut.cc
+++ b/loadgen/tests/perftests_null_sut.cc
@@ -30,6 +30,7 @@ class SystemUnderTestNull : public mlperf::SystemUnderTest {
     }
     mlperf::QuerySamplesComplete(responses.data(), responses.size());
   }
+
   void FlushQueries() override {}
   void ReportLatencyResults(
       const std::vector<mlperf::QuerySampleLatency>& latencies_ns) override {}
@@ -89,6 +90,8 @@ class SystemUnderTestNullStdAsync : public mlperf::SystemUnderTest {
       mlperf::QuerySamplesComplete(responses.data(), responses.size());
     }));
   }
+
+  void FlushQueries() override {}
   void ReportLatencyResults(
       const std::vector<mlperf::QuerySampleLatency>& latencies_ns) override {}
 
@@ -141,6 +144,7 @@ class SystemUnderTestNullPool : public mlperf::SystemUnderTest {
     samples_.insert(samples_.end(), samples.begin(), samples.end());
   }
 
+  void FlushQueries() override {}
   void ReportLatencyResults(
       const std::vector<mlperf::QuerySampleLatency>& latencies_ns) override {}
 


### PR DESCRIPTION
This makes the demos and perf tests compile and run again after recently landed patches broke them.