### PR TITLE
Removed invalid assert statement that fails in SubmissionRun mode

### DIFF
--- a/loadgen/loadgen.cc
+++ b/loadgen/loadgen.cc
@@ -304,9 +304,6 @@ std::vector<QueryMetadata> GenerateQueries(
 
   std::vector<QueryMetadata> queries;
 
-  assert(scenario == settings.scenario);
-  assert(mode == settings.mode);
-
   // Using the std::mt19937 pseudo-random number generator ensures a modicum of
   // cross platform reproducibility for trace generation.
   std::mt19937 sample_rng(settings.sample_index_rng_seed);


### PR DESCRIPTION
Assert statements in loadgen.cc were incorrectly firing when a run was performed in the SubmissionRun testing mode. As a fix, I have deleted the asserts for now. 