### PR TITLE
LoadGen: Simplify logging and tracing interface.

### DIFF
--- a/loadgen/loadgen.cc
+++ b/loadgen/loadgen.cc
@@ -356,9 +356,9 @@ std::vector<QueryMetadata> GenerateQueries(
   }
 
   LogDetail([count = queries.size(), spq = settings.samples_per_query,
-             duration = timestamp.count()](AsyncLog& log) {
-    log.LogDetail("GeneratedQueries: ", "queries", count, "samples per query",
-                  spq, "duration", duration);
+             duration = timestamp.count()](AsyncDetail& detail) {
+    detail("GeneratedQueries: ", "queries", count, "samples per query", spq,
+           "duration", duration);
   });
 
   return queries;
@@ -583,25 +583,24 @@ PerformanceResult IssueQueries(SystemUnderTest* sut,
     auto duration = (last_now - start);
     if (queries_issued >= settings.min_query_count &&
         duration > settings.min_duration) {
-      LogDetail([](AsyncLog& log) {
-        log.LogDetail(
-            "Ending naturally: Minimum query count and test duration met.");
+      LogDetail([](AsyncDetail& detail) {
+        detail("Ending naturally: Minimum query count and test duration met.");
       });
       break;
     }
     if (settings.max_query_count != 0 &&
         queries_issued >= settings.max_query_count) {
-      LogError([queries_issued](AsyncLog& log) {
-        log.LogDetail("Ending early: Max query count reached.", "query_count",
-                      queries_issued);
+      LogDetail([queries_issued](AsyncDetail& detail) {
+        detail.Error("Ending early: Max query count reached.", "query_count",
+                     queries_issued);
       });
       break;
     }
     if (settings.max_duration.count() != 0 &&
         duration > settings.max_duration) {
-      LogError([duration](AsyncLog& log) {
-        log.LogDetail("Ending early: Max test duration reached.", "duration_ns",
-                      duration.count());
+      LogDetail([duration](AsyncDetail& detail) {
+        detail.Error("Ending early: Max test duration reached.", "duration_ns",
+                     duration.count());
       });
       break;
     }
@@ -610,9 +609,9 @@ PerformanceResult IssueQueries(SystemUnderTest* sut,
           queries_issued -
           response_logger.queries_completed.load(std::memory_order_relaxed);
       if (queries_outstanding > max_queries_outstanding) {
-        LogError([queries_issued, queries_outstanding](AsyncLog& log) {
-          log.LogDetail("Ending early: Too many oustanding queries.", "issued",
-                        queries_issued, "outstanding", queries_outstanding);
+        LogDetail([queries_issued, queries_outstanding](AsyncDetail& detail) {
+          detail.Error("Ending early: Too many oustanding queries.", "issued",
+                       queries_issued, "outstanding", queries_outstanding);
         });
         break;
       }
@@ -628,11 +627,11 @@ PerformanceResult IssueQueries(SystemUnderTest* sut,
   // doesn't apply.
   if (scenario != TestScenario::Offline && mode == TestMode::PerformanceOnly &&
       queries_issued >= queries.size()) {
-    LogError([](AsyncLog& log) {
-      log.LogDetail(
+    LogDetail([](AsyncDetail& detail) {
+      detail.Error(
           "Ending early: Ran out of generated queries to issue before the "
           "minimum query count and test duration were reached.");
-      log.LogDetail(
+      detail(
           "Please update the relevant expected latency or target qps in the "
           "TestSettings so they are more accurate.");
     });
@@ -692,7 +691,7 @@ struct PerformanceSummary {
   bool MinSamplesMet();
   bool HasPerfConstraints();
   bool PerfConstraintsMet(std::string* recommendation);
-  void Log(AsyncLog& log);
+  void Log(AsyncSummary& summary);
 };
 
 void PerformanceSummary::ProcessLatencies() {
@@ -802,31 +801,31 @@ bool PerformanceSummary::PerfConstraintsMet(std::string* recommendation) {
   return perf_constraints_met;
 }
 
-void PerformanceSummary::Log(AsyncLog& log) {
+void PerformanceSummary::Log(AsyncSummary& summary) {
   ProcessLatencies();
 
-  log.LogSummary(
+  summary(
       "================================================\n"
       "MLPerf Results Summary\n"
       "================================================");
-  log.LogSummary("SUT name : ", sut_name);
-  log.LogSummary("Scenario : ", ToString(settings.scenario));
-  log.LogSummary("Mode     : ", ToString(settings.mode));
+  summary("SUT name : ", sut_name);
+  summary("Scenario : ", ToString(settings.scenario));
+  summary("Mode     : ", ToString(settings.mode));
 
   switch (settings.scenario) {
     case TestScenario::SingleStream: {
-      log.LogSummary("90th percentile latency (ns) : ", latency_target.value);
+      summary("90th percentile latency (ns) : ", latency_target.value);
       break;
     }
     case TestScenario::MultiStream: {
-      log.LogSummary("Samples per query : ", settings.samples_per_query);
+      summary("Samples per query : ", settings.samples_per_query);
       break;
     }
     case TestScenario::MultiStreamFree: {
       double samples_per_second = pr.queries_issued *
                                   settings.samples_per_query /
                                   pr.final_query_all_samples_done_time;
-      log.LogSummary("Samples per second : ", samples_per_second);
+      summary("Samples per second : ", samples_per_second);
       break;
     }
     case TestScenario::Server: {
@@ -840,13 +839,13 @@ void PerformanceSummary::Log(AsyncLog& log) {
       //    1000 queries / 1 second.
       double qps_as_scheduled =
           (sample_count - 1) / pr.final_query_scheduled_time;
-      log.LogSummary("Scheduled samples per second : ",
-                     DoubleToString(qps_as_scheduled));
+      summary("Scheduled samples per second : ",
+              DoubleToString(qps_as_scheduled));
       break;
     }
     case TestScenario::Offline: {
       double samples_per_second = sample_count / pr.max_latency;
-      log.LogSummary("Samples per second: ", samples_per_second);
+      summary("Samples per second: ", samples_per_second);
       break;
     }
   }
@@ -860,31 +859,30 @@ void PerformanceSummary::Log(AsyncLog& log) {
       PerfConstraintsMet(&perf_constraints_recommendation);
   bool all_constraints_met =
       min_duration_met && min_queries_met && perf_constraints_met;
-  log.LogSummary("Result is : ", all_constraints_met ? "VALID" : "INVALID");
+  summary("Result is : ", all_constraints_met ? "VALID" : "INVALID");
   if (HasPerfConstraints()) {
-    log.LogSummary("  Performance constraints satisfied : ",
-                   perf_constraints_met ? "Yes" : "NO");
+    summary("  Performance constraints satisfied : ",
+            perf_constraints_met ? "Yes" : "NO");
   }
-  log.LogSummary("  Min duration satisfied : ",
-                 min_duration_met ? "Yes" : "NO");
-  log.LogSummary("  Min queries satisfied : ", min_queries_met ? "Yes" : "NO");
+  summary("  Min duration satisfied : ", min_duration_met ? "Yes" : "NO");
+  summary("  Min queries satisfied : ", min_queries_met ? "Yes" : "NO");
 
   if (!all_constraints_met) {
-    log.LogSummary("Recommendations:");
+    summary("Recommendations:");
     if (!perf_constraints_met) {
-      log.LogSummary(" * " + perf_constraints_recommendation);
+      summary(" * " + perf_constraints_recommendation);
     }
     if (!min_duration_met) {
-      log.LogSummary(" * " + min_duration_recommendation);
+      summary(" * " + min_duration_recommendation);
     }
     if (!min_queries_met) {
-      log.LogSummary(
+      summary(
           " * The test exited early, before enough queries were issued.\n"
           "   See the detailed log for why this may have occured.");
     }
   }
 
-  log.LogSummary(
+  summary(
       "\n"
       "================================================\n"
       "Additional Stats\n"
@@ -893,46 +891,44 @@ void PerformanceSummary::Log(AsyncLog& log) {
   if (settings.scenario == TestScenario::SingleStream) {
     double qps_w_lg = (sample_count - 1) / pr.final_query_issued_time;
     double qps_wo_lg = 1 / QuerySampleLatencyToSeconds(latency_min);
-    log.LogSummary("QPS w/ loadgen overhead         : " +
-                   DoubleToString(qps_w_lg));
-    log.LogSummary("QPS w/o loadgen overhead        : " +
-                   DoubleToString(qps_wo_lg));
-    log.LogSummary("");
+    summary("QPS w/ loadgen overhead         : " + DoubleToString(qps_w_lg));
+    summary("QPS w/o loadgen overhead        : " + DoubleToString(qps_wo_lg));
+    summary("");
   } else if (settings.scenario == TestScenario::Server) {
     double qps_as_completed =
         (sample_count - 1) / pr.final_query_all_samples_done_time;
-    log.LogSummary("Completed samples per second    : ",
-                   DoubleToString(qps_as_completed));
-    log.LogSummary("");
+    summary("Completed samples per second    : ",
+            DoubleToString(qps_as_completed));
+    summary("");
   }
 
-  log.LogSummary("Min latency (ns)                : ", latency_min);
-  log.LogSummary("Max latency (ns)                : ", latency_max);
-  log.LogSummary("Mean latency (ns)               : ", latency_mean);
+  summary("Min latency (ns)                : ", latency_min);
+  summary("Max latency (ns)                : ", latency_max);
+  summary("Mean latency (ns)               : ", latency_mean);
   for (auto& lp : latency_percentiles) {
-    log.LogSummary(
+    summary(
         DoubleToString(lp.percentile * 100) + " percentile latency (ns)   : ",
         lp.value);
   }
 
-  log.LogSummary(
+  summary(
       "\n"
       "================================================\n"
       "Test Parameters Used\n"
       "================================================");
-  settings.LogSummary(log);
+  settings.LogSummary(summary);
 }
 
 void LoadSamplesToRam(QuerySampleLibrary* qsl,
                       const std::vector<QuerySampleIndex>& samples) {
-  LogDetail([&samples](AsyncLog& log) {
+  LogDetail([&samples](AsyncDetail& detail) {
     std::string set("\"[");
     for (auto i : samples) {
       set += std::to_string(i) + ",";
     }
     set.resize(set.size() - 1);
     set += "]\"";
-    log.LogDetail("Loading QSL : ", "set", set);
+    detail("Loading QSL : ", "set", set);
   });
   qsl->LoadSamplesToRam(samples);
 }
@@ -942,7 +938,7 @@ void RunPerformanceMode(SystemUnderTest* sut, QuerySampleLibrary* qsl,
                         const TestSettingsInternal& settings,
                         const std::vector<LoadableSampleSet>& loadable_sets,
                         SequenceGen* sequence_gen) {
-  LogDetail([](AsyncLog& log) { log.LogDetail("Starting performance mode:"); });
+  LogDetail([](AsyncDetail& detail) { detail("Starting performance mode:"); });
 
   // Use first loadable set as the performance set.
   const LoadableSampleSet& performance_set = loadable_sets.front();
@@ -953,8 +949,9 @@ void RunPerformanceMode(SystemUnderTest* sut, QuerySampleLibrary* qsl,
 
   sut->ReportLatencyResults(pr.latencies);
 
-  Log([perf_summary = PerformanceSummary{sut->Name(), settings, std::move(pr)}](
-          AsyncLog& log) mutable { perf_summary.Log(log); });
+  LogSummary(
+      [perf_summary = PerformanceSummary{sut->Name(), settings, std::move(pr)}](
+          AsyncSummary& summary) mutable { perf_summary.Log(summary); });
 
   qsl->UnloadSamplesFromRam(performance_set.set);
 }
@@ -965,8 +962,8 @@ void FindPeakPerformanceMode(
     const TestSettingsInternal& settings,
     const std::vector<LoadableSampleSet>& loadable_sets,
     SequenceGen* sequence_gen) {
-  LogDetail([](AsyncLog& log) {
-    log.LogDetail("Starting FindPeakPerformance mode:");
+  LogDetail([](AsyncDetail& detail) {
+    detail("Starting FindPeakPerformance mode:");
   });
 
   // Use first loadable set as the performance set.
@@ -992,7 +989,7 @@ void RunAccuracyMode(SystemUnderTest* sut, QuerySampleLibrary* qsl,
                      const TestSettingsInternal& settings,
                      const std::vector<LoadableSampleSet>& loadable_sets,
                      SequenceGen* sequence_gen) {
-  LogDetail([](AsyncLog& log) { log.LogDetail("Starting accuracy mode:"); });
+  LogDetail([](AsyncDetail& detail) { detail("Starting accuracy mode:"); });
 
   for (auto& loadable_set : loadable_sets) {
     {
@@ -1186,12 +1183,12 @@ void StartTest(SystemUnderTest* sut, QuerySampleLibrary* qsl,
   GlobalLogger().StartNewTrace(&log_outputs.trace_out, PerfClock::now());
 
   LogLoadgenVersion();
-  LogDetail([sut, qsl, test_date_time](AsyncLog& log) {
-    log.LogDetail("Date + time of test: ", test_date_time);
-    log.LogDetail("System Under Test (SUT) name: ", sut->Name());
-    log.LogDetail("Query Sample Library (QSL) name: ", qsl->Name());
-    log.LogDetail("QSL total size: ", qsl->TotalSampleCount());
-    log.LogDetail("QSL performance size: ", qsl->PerformanceSampleCount());
+  LogDetail([sut, qsl, test_date_time](AsyncDetail& detail) {
+    detail("Date + time of test: ", test_date_time);
+    detail("System Under Test (SUT) name: ", sut->Name());
+    detail("Query Sample Library (QSL) name: ", qsl->Name());
+    detail("QSL total size: ", qsl->TotalSampleCount());
+    detail("QSL performance size: ", qsl->PerformanceSampleCount());
   });
   TestSettingsInternal sanitized_settings(requested_settings);
   sanitized_settings.LogAllSettings();

--- a/loadgen/test_settings_internal.cc
+++ b/loadgen/test_settings_internal.cc
@@ -52,10 +52,10 @@ TestSettingsInternal::TestSettingsInternal(
       if (requested.server_target_qps >= 0.0) {
         target_qps = requested.server_target_qps;
       } else {
-        LogError([server_target_qps = requested.server_target_qps,
-                  target_qps = target_qps](AsyncLog &log) {
-          log.LogDetail("Invalid value for server_target_qps requested.",
-                        "requested", server_target_qps, "using", target_qps);
+        LogDetail([server_target_qps = requested.server_target_qps,
+                   target_qps = target_qps](AsyncDetail &detail) {
+          detail.Error("Invalid value for server_target_qps requested.",
+                       "requested", server_target_qps, "using", target_qps);
         });
       }
       target_latency =
@@ -67,10 +67,10 @@ TestSettingsInternal::TestSettingsInternal(
       if (requested.offline_expected_qps >= 0.0) {
         target_qps = requested.offline_expected_qps;
       } else {
-        LogError([offline_expected_qps = requested.offline_expected_qps,
-                  target_qps = target_qps](AsyncLog &log) {
-          log.LogDetail("Invalid value for offline_expected_qps requested.",
-                        "requested", offline_expected_qps, "using", target_qps);
+        LogDetail([offline_expected_qps = requested.offline_expected_qps,
+                   target_qps = target_qps](AsyncDetail &detail) {
+          detail.Error("Invalid value for offline_expected_qps requested.",
+                       "requested", offline_expected_qps, "using", target_qps);
         });
       }
       max_async_queries =
@@ -134,73 +134,72 @@ std::string ToString(TestMode mode) {
 }
 
 void LogRequestedTestSettings(const TestSettings &s) {
-  LogDetail([s](AsyncLog &log) {
-    log.LogDetail("");
-    log.LogDetail("Requested Settings:");
-    log.LogDetail("Scenario : " + ToString(s.scenario));
-    log.LogDetail("Test mode : " + ToString(s.mode));
+  LogDetail([s](AsyncDetail &detail) {
+    detail("");
+    detail("Requested Settings:");
+    detail("Scenario : " + ToString(s.scenario));
+    detail("Test mode : " + ToString(s.mode));
 
     // Scenario-specific
     switch (s.scenario) {
       case TestScenario::SingleStream:
-        log.LogDetail("single_stream_expected_latency_ns : ",
-                      s.single_stream_expected_latency_ns);
+        detail("single_stream_expected_latency_ns : ",
+               s.single_stream_expected_latency_ns);
         break;
       case TestScenario::MultiStream:
       case TestScenario::MultiStreamFree:
-        log.LogDetail("multi_stream_target_qps : ", s.multi_stream_target_qps);
-        log.LogDetail("multi_stream_target_latency_ns : ",
-                      s.multi_stream_target_latency_ns);
-        log.LogDetail("multi_stream_samples_per_query : ",
-                      s.multi_stream_samples_per_query);
-        log.LogDetail("multi_stream_max_async_queries : ",
-                      s.multi_stream_max_async_queries);
+        detail("multi_stream_target_qps : ", s.multi_stream_target_qps);
+        detail("multi_stream_target_latency_ns : ",
+               s.multi_stream_target_latency_ns);
+        detail("multi_stream_samples_per_query : ",
+               s.multi_stream_samples_per_query);
+        detail("multi_stream_max_async_queries : ",
+               s.multi_stream_max_async_queries);
         break;
       case TestScenario::Server:
-        log.LogDetail("server_target_qps : ", s.server_target_qps);
-        log.LogDetail("server_target_latency_ns : ",
-                      s.server_target_latency_ns);
-        log.LogDetail("server_coalesce_queries : ", s.server_coalesce_queries);
+        detail("server_target_qps : ", s.server_target_qps);
+        detail("server_target_latency_ns : ", s.server_target_latency_ns);
+        detail("server_coalesce_queries : ", s.server_coalesce_queries);
         break;
       case TestScenario::Offline:
-        log.LogDetail("offline_expected_qps : ", s.offline_expected_qps);
+        detail("offline_expected_qps : ", s.offline_expected_qps);
         break;
     }
 
     // Overrides
-    log.LogDetail("min_duration_ms : ", s.min_duration_ms);
-    log.LogDetail("max_duration_ms : ", s.max_duration_ms);
-    log.LogDetail("min_query_count : ", s.min_query_count);
-    log.LogDetail("max_query_count : ", s.max_query_count);
-    log.LogDetail("qsl_rng_seed : ", s.qsl_rng_seed);
-    log.LogDetail("sample_index_rng_seed : ", s.sample_index_rng_seed);
-    log.LogDetail("schedule_rng_seed : ", s.schedule_rng_seed);
+    detail("min_duration_ms : ", s.min_duration_ms);
+    detail("max_duration_ms : ", s.max_duration_ms);
+    detail("min_query_count : ", s.min_query_count);
+    detail("max_query_count : ", s.max_query_count);
+    detail("qsl_rng_seed : ", s.qsl_rng_seed);
+    detail("sample_index_rng_seed : ", s.sample_index_rng_seed);
+    detail("schedule_rng_seed : ", s.schedule_rng_seed);
 
-    log.LogDetail("");
+    detail("");
   });
 }
 
 void TestSettingsInternal::LogEffectiveSettings() const {
-  LogDetail([s = *this](AsyncLog &log) {
-    log.LogDetail("");
-    log.LogDetail("Effective Settings:");
+  LogDetail([s = *this](AsyncDetail &detail) {
+    detail("");
+    detail("Effective Settings:");
 
-    log.LogDetail("Scenario : " + ToString(s.scenario));
-    log.LogDetail("Test mode : " + ToString(s.mode));
+    detail("Scenario : " + ToString(s.scenario));
+    detail("Test mode : " + ToString(s.mode));
 
-    log.LogDetail("samples_per_query : ", s.samples_per_query);
-    log.LogDetail("target_qps : ", s.target_qps);
-    log.LogDetail("target_latency (ns): ", s.target_latency.count());
-    log.LogDetail("max_async_queries : ", s.max_async_queries);
-    log.LogDetail("target_duration (ms): ", s.target_duration.count());
-    log.LogDetail("min_duration (ms): ", s.min_duration.count());
-    log.LogDetail("max_duration (ms): ", s.max_duration.count());
-    log.LogDetail("min_query_count : ", s.min_query_count);
-    log.LogDetail("max_query_count : ", s.max_query_count);
-    log.LogDetail("min_sample_count : ", s.min_sample_count);
-    log.LogDetail("qsl_rng_seed : ", s.qsl_rng_seed);
-    log.LogDetail("sample_index_rng_seed : ", s.sample_index_rng_seed);
-    log.LogDetail("schedule_rng_seed : ", s.schedule_rng_seed);
+    detail("samples_per_query : ", s.samples_per_query);
+    detail("target_qps : ", s.target_qps);
+    detail("target_latency (ns): ", s.target_latency.count());
+    detail("max_async_queries : ", s.max_async_queries);
+    detail("target_duration (ms): ", s.target_duration.count());
+    detail("min_duration (ms): ", s.min_duration.count());
+    detail("max_duration (ms): ", s.max_duration.count());
+    detail("min_query_count : ", s.min_query_count);
+    detail("max_query_count : ", s.max_query_count);
+    detail("min_sample_count : ", s.min_sample_count);
+    detail("qsl_rng_seed : ", s.qsl_rng_seed);
+    detail("sample_index_rng_seed : ", s.sample_index_rng_seed);
+    detail("schedule_rng_seed : ", s.schedule_rng_seed);
   });
 }
 
@@ -209,18 +208,18 @@ void TestSettingsInternal::LogAllSettings() const {
   LogRequestedTestSettings(requested);
 }
 
-void TestSettingsInternal::LogSummary(AsyncLog &log) const {
-  log.LogSummary("samples_per_query : ", samples_per_query);
-  log.LogSummary("target_qps : ", target_qps);
-  log.LogSummary("target_latency (ns): ", target_latency.count());
-  log.LogSummary("max_async_queries : ", max_async_queries);
-  log.LogSummary("min_duration (ms): ", min_duration.count());
-  log.LogSummary("max_duration (ms): ", max_duration.count());
-  log.LogSummary("min_query_count : ", min_query_count);
-  log.LogSummary("max_query_count : ", max_query_count);
-  log.LogSummary("qsl_rng_seed : ", qsl_rng_seed);
-  log.LogSummary("sample_index_rng_seed : ", sample_index_rng_seed);
-  log.LogSummary("schedule_rng_seed : ", schedule_rng_seed);
+void TestSettingsInternal::LogSummary(AsyncSummary &summary) const {
+  summary("samples_per_query : ", samples_per_query);
+  summary("target_qps : ", target_qps);
+  summary("target_latency (ns): ", target_latency.count());
+  summary("max_async_queries : ", max_async_queries);
+  summary("min_duration (ms): ", min_duration.count());
+  summary("max_duration (ms): ", max_duration.count());
+  summary("min_query_count : ", min_query_count);
+  summary("max_query_count : ", max_query_count);
+  summary("qsl_rng_seed : ", qsl_rng_seed);
+  summary("sample_index_rng_seed : ", sample_index_rng_seed);
+  summary("schedule_rng_seed : ", schedule_rng_seed);
 }
 
 }  // namespace mlperf

--- a/loadgen/test_settings_internal.h
+++ b/loadgen/test_settings_internal.h
@@ -20,7 +20,7 @@ limitations under the License.
 
 namespace mlperf {
 
-class AsyncLog;
+class AsyncSummary;
 
 std::string ToString(TestScenario scenario);
 std::string ToString(TestMode mode);
@@ -33,7 +33,7 @@ struct TestSettingsInternal {
   explicit TestSettingsInternal(const TestSettings& requested_settings);
   void LogEffectiveSettings() const;
   void LogAllSettings() const;
-  void LogSummary(AsyncLog& log) const;
+  void LogSummary(AsyncSummary& summary) const;
 
   const TestSettings requested;
   const TestScenario scenario;  // Copied here for convenience.

--- a/loadgen/version.cc
+++ b/loadgen/version.cc
@@ -17,20 +17,18 @@ limitations under the License.
 namespace mlperf {
 
 void LogLoadgenVersion() {
-  LogDetail([](AsyncLog& log) {
-    log.LogDetail("LoadgenVersionInfo:");
-    log.LogDetail("version : " + LoadgenVersion() + " @ " +
-                  LoadgenGitRevision());
-    log.LogDetail("build_date_local : " + LoadgenBuildDateLocal());
-    log.LogDetail("build_date_utc   : " + LoadgenBuildDateUtc());
-    log.LogDetail("git_commit_date  : " + LoadgenGitCommitDate());
-    log.LogDetail("git_log :\n\n" + LoadgenGitLog() + "\n");
-    log.LogDetail("git_status :\n\n" + LoadgenGitStatus() + "\n");
+  LogDetail([](AsyncDetail &detail) {
+    detail("LoadgenVersionInfo:");
+    detail("version : " + LoadgenVersion() + " @ " + LoadgenGitRevision());
+    detail("build_date_local : " + LoadgenBuildDateLocal());
+    detail("build_date_utc   : " + LoadgenBuildDateUtc());
+    detail("git_commit_date  : " + LoadgenGitCommitDate());
+    detail("git_log :\n\n" + LoadgenGitLog() + "\n");
+    detail("git_status :\n\n" + LoadgenGitStatus() + "\n");
     if (!LoadgenGitStatus().empty() && LoadgenGitStatus() != "NA") {
-      log.FlagError();
-      log.LogDetail("Loadgen built with uncommitted changes!");
+      detail.Error("Loadgen built with uncommitted changes!");
     }
-    log.LogDetail("SHA1 of files :\n\n" + LoadgenSha1OfFiles() + "\n");
+    detail("SHA1 of files :\n\n" + LoadgenSha1OfFiles() + "\n");
   });
 }
 


### PR DESCRIPTION
Prior to this patch, logging errors and detail logs was
error prone because we'd have to call matching functions
from the producing thread and on the consumer thread
inside the lambda. Not calling the matching functions
would result in silent unexpected behavior.

This patch:
* Adds LogSummary and LogDetail functions that automatically
  call the corresponding method on the
  AsyncLog using a functor proxy.
* The LogDetail proxy has an Error() method to report errors
  in the detail log.
* The functor proxies also provide access to the underyling
  AsyncLog as an escape hatch.

Using the AsyncLog directly is still supported since it's
useful to log multiple types of messages within a single
lambda.

Note: ScopedTraces have not been converted yet, but could
benefit from a similar change.