### PR TITLE
[green] change preprocess module from PIL to opencv

### DIFF
--- a/v0.5/classification_and_detection/python/imagenet.py
+++ b/v0.5/classification_and_detection/python/imagenet.py
@@ -4,6 +4,7 @@ implementation of imagenet dataset
 
 # pylint: disable=unused-argument,missing-docstring
 
+import cv2
 import logging
 import os
 import re
@@ -60,10 +61,10 @@ class Imagenet(dataset.Dataset):
                 if not os.path.exists(dst + ".npy"):
                     # cache a preprocessed version of the image
                     # TODO: make this multi threaded ?
-                    with Image.open(src) as img_org:
-                        processed = self.pre_process(img_org, need_transpose=self.need_transpose, dims=self.image_size)
-                        np.save(dst, processed)
-
+                    img_org = cv2.imread(src)
+                    processed = self.pre_process(img_org, need_transpose=self.need_transpose, dims=self.image_size)
+                    np.save(dst, processed)
+                
                 self.image_list.append(image_name)
                 self.label_list.append(int(label))
 


### PR DESCRIPTION
      1. python module PIL's resize method is not as precise as opencv
         when changed module from PIL to cv2, classification topology mobilenet
         top-1 accuracy can improve from 71.23 to 71.68 and resnet50 can improve from
         76.16 to 76.46