### PR TITLE
Install LoadGen lib and headers to CMAKE_INSTALL_PREFIX

### DIFF
--- a/loadgen/CMakeLists.txt
+++ b/loadgen/CMakeLists.txt
@@ -38,3 +38,9 @@ set(SOURCE
 
 add_library(mlperf_loadgen STATIC ${SOURCE})
 target_link_libraries(mlperf_loadgen)
+
+# Install library and headers.
+install(TARGETS mlperf_loadgen
+	DESTINATION ${CMAKE_INSTALL_PREFIX}/lib)
+install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/
+	DESTINATION ${CMAKE_INSTALL_PREFIX}/include FILES_MATCHING PATTERN "*.h")

--- a/loadgen/README.md
+++ b/loadgen/README.md
@@ -26,7 +26,7 @@ To build the loadgen as a C++ library, rather than a python module:
 
 Alternatively:
 
-    git clone --recurse-submodules https://github.com/mlperf/inference.git mlperf_inference
+    git clone https://github.com/mlperf/inference.git mlperf_inference
     cd mlperf_inference
     mkdir loadgen/build/ && cd loadgen/build/
     cmake .. && cmake --build .


### PR DESCRIPTION
You can configure where the LoadGen library and headers get installed as follows:
```
# Configure.
mkdir ${BUILD_DIR} && cd ${BUILD_DIR}
cmake ${SOURCE_DIR} \
  -DCMAKE_INSTALL_PREFIX="${INSTALL_DIR}"

# Build and install.
cmake \
  --build ${BUILD_DIR} \
  --target install
```