### PR TITLE
LoadGen: Add tests for "remainder" samples.

### DIFF
--- a/loadgen/tests/BUILD.gn
+++ b/loadgen/tests/BUILD.gn
@@ -1,5 +1,6 @@
 static_library("mlperf_loadgen_tests_loadgen_test_main") {
   sources = [ "loadgen_test.h", "loadgen_test_main.cc" ]
+  configs += [ "//build/config/compiler:exceptions" ]
 }
 
 executable("mlperf_loadgen_perftests") {
@@ -12,6 +13,7 @@ executable("mlperf_loadgen_tests_basic") {
   sources = [ "basic.cc" ]
   deps = [ "..:mlperf_loadgen",
            ":mlperf_loadgen_tests_loadgen_test_main"  ]
+  configs += [ "//build/config/compiler:exceptions" ]
 }
 
 source_set("mlperf_loadgen_perftests_py") {

--- a/loadgen/tests/basic.cc
+++ b/loadgen/tests/basic.cc
@@ -11,6 +11,7 @@ limitations under the License.
 ==============================================================================*/
 
 #include <algorithm>
+#include <deque>
 #include <future>
 #include <iostream>
 #include <queue>
@@ -23,17 +24,12 @@ limitations under the License.
 #include "../test_settings.h"
 #include "loadgen_test.h"
 
-class SystemUnderTestBasic : public mlperf::QuerySampleLibrary,
-                             public mlperf::SystemUnderTest {
- public:
-  SystemUnderTestBasic(size_t total_sample_count,
-                       size_t performance_sample_count)
-      : total_sample_count_(total_sample_count),
-        performance_sample_count_(performance_sample_count),
-        samples_load_count_(total_sample_count, 0),
-        samples_issue_count_(total_sample_count, 0) {}
-
-  ~SystemUnderTestBasic() override = default;
+// SystemUnderTestBasic implements the client interfaces of the loadgen and
+// has some basic sanity checks that are enabled for all tests.
+// It also forwards calls to overrideable *Ext methods and implements
+// the TestProxy concept.
+struct SystemUnderTestBasic : public mlperf::QuerySampleLibrary,
+                              public mlperf::SystemUnderTest {
   const std::string& Name() const override { return name_; }
 
   size_t TotalSampleCount() override { return total_sample_count_; }
@@ -43,23 +39,31 @@ class SystemUnderTestBasic : public mlperf::QuerySampleLibrary,
       const std::vector<mlperf::QuerySampleIndex>& samples) override {
     for (auto s : samples) {
       samples_load_count_.at(s)++;
-      loaded_samples_.push(s);
+      loaded_samples_.push_back(s);
     }
+    LoadSamplesToRamExt(samples);
   }
+  virtual void LoadSamplesToRamExt(
+      const std::vector<mlperf::QuerySampleIndex>& samples) {}
 
   void UnloadSamplesFromRam(
       const std::vector<mlperf::QuerySampleIndex>& samples) override {
     for (auto s : samples) {
       FAIL_IF(loaded_samples_.front() != s) &&
           FAIL_EXP(loaded_samples_.front()) && FAIL_EXP(s);
-      loaded_samples_.pop();
+      loaded_samples_.pop_front();
       size_t prev_load_count = samples_load_count_.at(s)--;
       FAIL_IF(prev_load_count == 0) && FAIL_EXP(prev_load_count);
     }
+    UnloadSamplesFromRamExt(samples);
   }
+  virtual void UnloadSamplesFromRamExt(
+      const std::vector<mlperf::QuerySampleIndex>& samples) {}
 
   void IssueQuery(const std::vector<mlperf::QuerySample>& samples) override {
     std::vector<mlperf::QuerySampleResponse> responses;
+    query_sizes_.push_back(samples.size());
+    samples_between_flushes_.back() += samples.size();
     responses.reserve(samples.size());
     for (auto s : samples) {
       FAIL_IF(samples_load_count_.at(s.index) == 0) &&
@@ -69,81 +73,205 @@ class SystemUnderTestBasic : public mlperf::QuerySampleLibrary,
       responses.push_back({s.id, 0, 0});
     }
     mlperf::QuerySamplesComplete(responses.data(), responses.size());
+    IssueQueryExt(samples);
   }
+  virtual void IssueQueryExt(const std::vector<mlperf::QuerySample>& samples) {}
 
-  void FlushQueries() override {}
+  void FlushQueries() override {
+    samples_between_flushes_.push_back(0);
+    FlushQueriesExt();
+  }
+  virtual void FlushQueriesExt() {}
+
   void ReportLatencyResults(
       const std::vector<mlperf::QuerySampleLatency>& latencies_ns) override {}
 
-  std::vector<mlperf::QuerySampleIndex> GetIssuedSamples() {
-    return std::move(issued_samples_);
+  virtual void RunTest() {
+    samples_load_count_.resize(total_sample_count_, 0);
+    samples_issue_count_.resize(total_sample_count_, 0);
+    samples_between_flushes_.resize(1, 0);
+    mlperf::StartTest(this, this, test_settings_, log_settings_);
   }
 
- private:
+  virtual void EndTest() {}
+
+ protected:
+  mlperf::TestSettings test_settings_;
+  mlperf::LogSettings log_settings_;
+
   std::string name_{"BasicSUT"};
-  const size_t total_sample_count_;
-  const size_t performance_sample_count_;
+  size_t total_sample_count_;
+  size_t performance_sample_count_;
   std::vector<mlperf::QuerySampleIndex> issued_samples_;
-  std::queue<mlperf::QuerySampleIndex> loaded_samples_;
+  std::deque<mlperf::QuerySampleIndex> loaded_samples_;
   std::vector<size_t> samples_load_count_;
   std::vector<size_t> samples_issue_count_;
+
+  std::vector<size_t> query_sizes_;
+  std::vector<size_t> samples_between_flushes_;
 };
 
-void TestAccuracyIncludesAllSamples(mlperf::TestScenario scenario) {
-  const size_t kSamplesPerQuery = 4;
-  const size_t kPerformanceSampleCount = kSamplesPerQuery * 16;
-  // Make sure performance set size doesn't divide total size evenly.
-  const size_t kSampleRemainder = 7;
-  const size_t kTotalSampleCount =
-      kPerformanceSampleCount * 32 + kSampleRemainder;
-  const size_t kExpectedSets = kTotalSampleCount / kPerformanceSampleCount;
+struct SystemUnderTestAccuracy : public SystemUnderTestBasic {
+  virtual void SetUpTest(size_t samples_per_query,
+                         size_t samples_per_query_remainder,
+                         size_t accuracy_remainder,
+                         mlperf::TestScenario scenario) {
+    performance_sample_count_ =
+        samples_per_query * 16 + samples_per_query_remainder;
+    total_sample_count_ = performance_sample_count_ * 32 + accuracy_remainder;
 
-  SystemUnderTestBasic sut(kTotalSampleCount, kPerformanceSampleCount);
+    log_settings_.log_output.prefix_with_datetime = false;
 
-  mlperf::LogSettings log_settings;
-  log_settings.log_output.prefix_with_datetime = true;
+    test_settings_.scenario = scenario;
+    test_settings_.mode = mlperf::TestMode::AccuracyOnly;
+    test_settings_.multi_stream_samples_per_query = samples_per_query;
 
-  mlperf::TestSettings ts;
-  ts.scenario = scenario;
-  ts.mode = mlperf::TestMode::AccuracyOnly;
-  ts.multi_stream_samples_per_query = kSamplesPerQuery;
+    double qps = 1e3;
+    test_settings_.server_target_qps = qps;
+    test_settings_.multi_stream_target_qps = qps;
+  }
+};
 
-  double qps = 1e3;
-  ts.server_target_qps = qps;
-  ts.multi_stream_target_qps = qps;
+struct TestAccuracyIncludesAllSamples : public SystemUnderTestAccuracy {
+  void EndTest() override {
+    std::sort(issued_samples_.begin(), issued_samples_.end());
 
-  mlperf::StartTest(&sut, &sut, ts, log_settings);
+    FAIL_IF(issued_samples_.size() < total_sample_count_) &&
+        FAIL_EXP(issued_samples_.size()) && FAIL_EXP(total_sample_count_);
+    FAIL_IF(issued_samples_.front() != 0) && FAIL_EXP(issued_samples_.front());
+    FAIL_IF(issued_samples_.back() != total_sample_count_ - 1) &&
+        FAIL_EXP(issued_samples_.back()) && FAIL_EXP(total_sample_count_);
 
-  std::vector<mlperf::QuerySampleIndex> issued_samples(sut.GetIssuedSamples());
-
-  std::sort(issued_samples.begin(), issued_samples.end());
-
-  FAIL_IF(issued_samples.size() < kTotalSampleCount) &&
-      FAIL_EXP(issued_samples.size()) && FAIL_EXP(kTotalSampleCount);
-  FAIL_IF(issued_samples.front() != 0) && FAIL_EXP(issued_samples.front());
-  FAIL_IF(issued_samples.back() != kTotalSampleCount - 1) &&
-      FAIL_EXP(issued_samples.back()) && FAIL_EXP(kTotalSampleCount);
-
-  mlperf::QuerySampleIndex prev = -1;
-  size_t discontinuities = 0;
-  size_t dupes = 0;
-  for (auto s : issued_samples) {
-    if (s == prev) {
-      dupes++;
-    } else if (s - prev > 1) {
-      discontinuities++;
+    mlperf::QuerySampleIndex prev = -1;
+    size_t discontinuities = 0;
+    size_t dupes = 0;
+    for (auto s : issued_samples_) {
+      if (s == prev) {
+        dupes++;
+      } else if (s - prev > 1) {
+        discontinuities++;
+      }
+      prev = s;
     }
-    prev = s;
-  }
 
-  FAIL_IF(discontinuities != 0) && FAIL_EXP(discontinuities);
-  if (scenario == mlperf::TestScenario::MultiStream ||
-      scenario == mlperf::TestScenario::MultiStreamFree) {
-    FAIL_IF(dupes >= kSamplesPerQuery * kExpectedSets) && FAIL_EXP(dupes);
-  } else {
-    FAIL_IF(dupes != 0) && FAIL_EXP(dupes);
+    FAIL_IF(discontinuities != 0) && FAIL_EXP(discontinuities);
+    if (test_settings_.scenario == mlperf::TestScenario::MultiStream ||
+        test_settings_.scenario == mlperf::TestScenario::MultiStreamFree) {
+      const size_t expected_sets =
+          total_sample_count_ / performance_sample_count_;
+      FAIL_IF(dupes >=
+              test_settings_.multi_stream_samples_per_query * expected_sets) &&
+          FAIL_EXP(dupes);
+    } else {
+      FAIL_IF(dupes != 0) && FAIL_EXP(dupes);
+    }
   }
-}
+};
 
 REGISTER_TEST_ALL_SCENARIOS(AccuracyIncludesAllSamples,
-                            TestAccuracyIncludesAllSamples);
+                            TestProxy<TestAccuracyIncludesAllSamples>(), 4, 0,
+                            0);
+
+// Verifies
+struct TestOfflineRemainderAccuracySet : public SystemUnderTestAccuracy {
+  void SetUpTest() {
+    SystemUnderTestAccuracy::SetUpTest(4, 0, 7, mlperf::TestScenario::Offline);
+  }
+
+  void EndTest() override {
+    auto& flush_samples = samples_between_flushes_;
+
+    FAIL_IF(flush_samples.size() < 3) && FAIL_EXP(flush_samples.size()) &&
+        BAD_TEST_MSG("Test should generate multiple query sets.") && ABORT_TEST;
+
+    // The last counter will be 0, since a test ends with a call to
+    // FlushQuery.
+    FAIL_IF(flush_samples.back() != 0) && FAIL_EXP(flush_samples.back()) &&
+        FAIL_MSG(
+            "Detected stray calls to IssueQuery after the last call to "
+            "FlushQuery.");
+    flush_samples.pop_back();
+
+    // Verify the test ran with a smaller last accuracy set.
+    size_t first_size = flush_samples.front();
+    size_t last_size = flush_samples.back();
+    FAIL_IF(first_size <= last_size) && FAIL_EXP(first_size) &&
+        FAIL_EXP(last_size) && BAD_TEST_MSG();
+
+    flush_samples.pop_back();  // Don't check the last set for equality.
+    for (size_t query_size : flush_samples) {
+      FAIL_IF(query_size != first_size) && FAIL_EXP(query_size) &&
+          FAIL_EXP(first_size);
+    }
+  }
+};
+
+REGISTER_TEST(Offline_RemainderAccuracySets,
+              TestProxy<TestOfflineRemainderAccuracySet>());
+
+// Verifies all queries only contain samples that are contiguous
+// as defined by the sample order in LoadSamplesToRam, even if
+// the set size is not a multiple of samples_per_query.
+struct TestMultiStreamContiguousRemainderQuery
+    : public SystemUnderTestAccuracy {
+  void SetUpTest(mlperf::TestScenario scenario) {
+    SystemUnderTestAccuracy::SetUpTest(4, 1, 0, scenario);
+    first_qsl_offsets_.resize(total_sample_count_, kBadQslOffset);
+
+    auto spq = test_settings_.multi_stream_samples_per_query;
+    FAIL_IF(performance_sample_count_ % spq == 0) &&
+        FAIL_EXP(performance_sample_count_) && FAIL_EXP(spq) &&
+        BAD_TEST_MSG("There is no remainder.");
+  }
+
+  void LoadSamplesToRamExt(
+      const std::vector<mlperf::QuerySampleIndex>& samples) override {
+    FAIL_IF(loaded_samples_.size() != samples.size()) &&
+        FAIL_MSG("Contiguous sample order is likely ambiguous.");
+    for (size_t i = 0; i < samples.size(); i++) {
+      auto& offset = first_qsl_offsets_.at(samples.at(i));
+      // Samples may be loaded into multiple slots for paddign purposes,
+      // so make sure to only index the first time a sample appears in a
+      // loaded set.
+      if (offset == kBadQslOffset) {
+        offset = i;
+      }
+    }
+  }
+
+  void UnloadSamplesFromRamExt(
+      const std::vector<mlperf::QuerySampleIndex>& samples) override {
+    FAIL_IF(!loaded_samples_.empty()) &&
+        FAIL_MSG("Contiguous sample order is likely ambiguous.");
+    for (size_t i = 0; i < samples.size(); i++) {
+      first_qsl_offsets_.at(samples.at(i)) = kBadQslOffset;
+    }
+  }
+
+  void IssueQueryExt(const std::vector<mlperf::QuerySample>& samples) override {
+    size_t expected_offset = first_qsl_offsets_[samples[0].index];
+    for (auto s : samples) {
+      FAIL_IF(loaded_samples_[expected_offset] != s.index) &&
+          FAIL_MSG("Samples are not contiguous.");
+      expected_offset++;
+    }
+  }
+
+  void FlushQueriesExt() override {}
+
+  void EndTest() override {}
+
+ private:
+  static const size_t kBadQslOffset;
+  std::vector<size_t> first_qsl_offsets_;
+};
+
+constexpr size_t TestMultiStreamContiguousRemainderQuery::kBadQslOffset =
+    std::numeric_limits<size_t>::max();
+
+REGISTER_TEST(MultiStream_RemainderQueryContiguous,
+              TestProxy<TestMultiStreamContiguousRemainderQuery>(),
+              mlperf::TestScenario::MultiStream);
+REGISTER_TEST(MultiStreamFree_RemainderQueryContiguous,
+              TestProxy<TestMultiStreamContiguousRemainderQuery>(),
+              mlperf::TestScenario::MultiStreamFree);


### PR DESCRIPTION
Adds a test to verify we don't hang in the
offline scenario in accuracy mode when the
last loadable set is smaller than the rest.

Adds a test to verify MultiStream scenario
has contiguous samples in the accuracy mode
even when the loadable set size is not an
exact multiple of samples_per_query.