### PR TITLE
Add the flag 'CMAKE_CXX_STANDARD' to loadgen/CMakeLists.txt.

### DIFF
--- a/loadgen/CMakeLists.txt
+++ b/loadgen/CMakeLists.txt
@@ -9,7 +9,9 @@ message("mlperf_loadgen v${mlperf_loadgen_VERSION_MAJOR}.${mlperf_loadgen_VERSIO
 
 # Set build options.
 set(CMAKE_CXX_FLAGS "-O2 -W -Wall")
+set(CMAKE_CXX_STANDARD "14")
 message(STATUS "Using compiler flags: ${CMAKE_CXX_FLAGS}")
+message(STATUS "Using c++ standard flags: ${CMAKE_CXX_STANDARD}")
 message(STATUS "Using static linker flags: ${CMAKE_STATIC_LINKER_FLAGS}")
 message(STATUS "Using shared linker flags: ${CMAKE_SHARED_LINKER_FLAGS}")
 


### PR DESCRIPTION
`cmake`  building instructions in the loadgen README isn't working now. To compile the loadgen using `cmake`, the flag 'CMAKE_CXX_STANDARD' is necessary.
An alternative way to use the flag is `cmake -DCMAKE_CXX_STANDARD 14 .. && cmake --build .`, but I think that specifying it in `CMakeLists.txt` is an easier way to use. 