### PR TITLE
Silence Clang warnings on LoadGen

### DIFF
--- a/loadgen/bindings/c_api.cc
+++ b/loadgen/bindings/c_api.cc
@@ -97,8 +97,8 @@ class QuerySampleLibraryTrampoline : public QuerySampleLibrary {
   ~QuerySampleLibraryTrampoline() override = default;
 
   const std::string& Name() const override { return name_; }
-  size_t TotalSampleCount() { return total_sample_count_; }
-  size_t PerformanceSampleCount() { return performance_sample_count_; }
+  size_t TotalSampleCount() override { return total_sample_count_; }
+  size_t PerformanceSampleCount() override { return performance_sample_count_; }
 
   void LoadSamplesToRam(const std::vector<QuerySampleIndex>& samples) override {
     (*load_samples_to_ram_cb_)(client_data_, samples.data(), samples.size());

--- a/loadgen/loadgen.cc
+++ b/loadgen/loadgen.cc
@@ -38,7 +38,7 @@ limitations under the License.
 namespace mlperf {
 
 struct SampleMetadata;
-struct QueryMetadata;
+class QueryMetadata;
 
 // Every query and sample within a call to StartTest gets a unique sequence id
 // for easy cross reference.
@@ -1056,9 +1056,9 @@ struct RunFunctions {
     return GetCompileTime<TestScenario::SingleStream>();
   }
 
-  const Signature& accuracy;
-  const Signature& performance;
-  const Signature& find_peak_performance;
+  Signature& accuracy;
+  Signature& performance;
+  Signature& find_peak_performance;
 };
 
 // Generates random sets of samples in the QSL that we can load into RAM

--- a/loadgen/logging.h
+++ b/loadgen/logging.h
@@ -36,7 +36,7 @@ namespace mlperf {
 class AsyncLog;
 class Logger;
 class TlsLogger;
-class TlsLoggerWrapper;
+struct TlsLoggerWrapper;
 
 using AsyncLogEntry = std::function<void(AsyncLog&)>;
 using PerfClock = std::chrono::high_resolution_clock;


### PR DESCRIPTION
When building with Clang 6, we got a few warnings:
```
[ 12%] Building CXX object CMakeFiles/mlperf_loadgen.dir/bindings/c_api.cc.o
/home/anton/CK_TOOLS/mlperf-inference-dividiti.master/inference/loadgen/bindings/c_api.cc:100:10: warning: 'TotalSampleCount' overrides a member function but is not marked 'override'
      [-Winconsistent-missing-override]                                                                                                 
  size_t TotalSampleCount() { return total_sample_count_; }                                                             
         ^                                                                                                                                         
/home/anton/CK_TOOLS/mlperf-inference-dividiti.master/inference/loadgen/bindings/../query_sample_library.h:36:18: note: overridden virtual function is here
  virtual size_t TotalSampleCount() = 0;                                                                                                          
                 ^                                                                                                                
/home/anton/CK_TOOLS/mlperf-inference-dividiti.master/inference/loadgen/bindings/c_api.cc:101:10: warning: 'PerformanceSampleCount' overrides a member function but is not marked 'override'
      [-Winconsistent-missing-override]                                                                                          
  size_t PerformanceSampleCount() { return performance_sample_count_; }
         ^
/home/anton/CK_TOOLS/mlperf-inference-dividiti.master/inference/loadgen/bindings/../query_sample_library.h:39:18: note: overridden virtual function is here
  virtual size_t PerformanceSampleCount() = 0;
                 ^
2 warnings generated.
[ 25%] Building CXX object CMakeFiles/mlperf_loadgen.dir/loadgen.cc.o
/home/anton/CK_TOOLS/mlperf-inference-dividiti.master/inference/loadgen/loadgen.cc:75:1: warning: 'QueryMetadata' defined as a class here but previously declared as a struct [-Wmismatched-tags]
class QueryMetadata {
^
/home/anton/CK_TOOLS/mlperf-inference-dividiti.master/inference/loadgen/loadgen.cc:41:1: note: did you mean class here?
struct QueryMetadata;
^~~~~~
class
/home/anton/CK_TOOLS/mlperf-inference-dividiti.master/inference/loadgen/loadgen.cc:1059:3: warning: 'const' qualifier on function type 'mlperf::RunFunctions::Signature' (aka 'void (mlperf::SystemUnderTest
      *, mlperf::QuerySampleLibrary *, const mlperf::TestSettingsInternal &, const std::vector<LoadableSampleSet> &, mlperf::SequenceGen *)') has no effect [-Wignored-qualifiers]
  const Signature& accuracy;
  ^~~~~~
/home/anton/CK_TOOLS/mlperf-inference-dividiti.master/inference/loadgen/loadgen.cc:1060:3: warning: 'const' qualifier on function type 'mlperf::RunFunctions::Signature' (aka 'void (mlperf::SystemUnderTest
      *, mlperf::QuerySampleLibrary *, const mlperf::TestSettingsInternal &, const std::vector<LoadableSampleSet> &, mlperf::SequenceGen *)') has no effect [-Wignored-qualifiers]
  const Signature& performance;
  ^~~~~~
/home/anton/CK_TOOLS/mlperf-inference-dividiti.master/inference/loadgen/loadgen.cc:1061:3: warning: 'const' qualifier on function type 'mlperf::RunFunctions::Signature' (aka 'void (mlperf::SystemUnderTest
      *, mlperf::QuerySampleLibrary *, const mlperf::TestSettingsInternal &, const std::vector<LoadableSampleSet> &, mlperf::SequenceGen *)') has no effect [-Wignored-qualifiers]
  const Signature& find_peak_performance;
  ^~~~~~
4 warnings generated.
[ 37%] Building CXX object CMakeFiles/mlperf_loadgen.dir/logging.cc.o
/home/anton/CK_TOOLS/mlperf-inference-dividiti.master/inference/loadgen/logging.cc:817:1: warning: 'TlsLoggerWrapper' defined as a struct here but previously declared as a class [-Wmismatched-tags]
struct TlsLoggerWrapper {
^
/home/anton/CK_TOOLS/mlperf-inference-dividiti.master/inference/loadgen/logging.h:39:1: note: did you mean struct here?
class TlsLoggerWrapper;
^~~~~
struct
1 warning generated.
```
which this PR silences.