### PR TITLE
[loadGen] Added Offline Contiguous mode.

### DIFF
--- a/loadgen/loadgen.cc
+++ b/loadgen/loadgen.cc
@@ -339,6 +339,22 @@ std::vector<QueryMetadata> GenerateQueries(
         // query as the value of samples_per_query increases.
         s = loaded_samples[sample_i++];
       }
+    } else if(mode == TestMode::PerformanceOnly && scenario == TestScenario::Offline ){
+      // For the Offline + Performance scenario, we also want to support
+      // contiguous samples. In this scenario the query can be much larger than what
+      // fits into memory. We simply repeat loaded_samples N times, plus a remainder
+      // to ensure we fill up samples.
+      // Note that this eliminates randomization.
+      size_t num_loaded_samples = loaded_samples.size();
+      size_t num_full_repeats = samples_per_query/num_loaded_samples;
+      int remainder = samples_per_query % (num_loaded_samples);
+
+      for (int i = 0; i < num_full_repeats; ++i){
+        std::copy (loaded_samples.begin(), loaded_samples.end(), samples.begin() + i * num_loaded_samples);
+      }
+
+      std::copy(loaded_samples.begin(), loaded_samples.begin() + remainder, samples.begin() + num_full_repeats * num_loaded_samples);
+
     } else {
       for (auto& s : samples) {
         s = loaded_samples[sample_distribution(sample_rng)];
@@ -763,7 +779,7 @@ bool PerformanceSummary::MinDurationMet(std::string* recommendation) {
       break;
     case TestScenario::Offline:
       *recommendation =
-          "Increase expected QPS so the loadgen pre-generates more queries.";
+          "Increase expected QPS so the loadgen pre-generates a larger (coalesced) query.";
       break;
   }
   return false;


### PR DESCRIPTION
This addresses issue #225 

We cannot use padding as in the MultiStream scenario, since samples_per_query can be too large to fit in memory. As a simple solution, we repeat PerformanceSampleCount a number of times, so that it totals samples_per_query.

Note that this is not entirely contiguous: contiguity gets interrupted after every stamp of PerformanceSampleCount samples. 