### PR TITLE
Print mAP in percent as intended

### DIFF
--- a/v0.5/classification_and_detection/python/main.py
+++ b/v0.5/classification_and_detection/python/main.py
@@ -397,7 +397,7 @@ def add_results(final_results, name, result_dict, result_list, took, show_accura
         acc_str = ", acc={:.3f}%".format(result["accuracy"])
         if "mAP" in result_dict:
             result["mAP"] = 100. * result_dict["mAP"]
-            acc_str += ", mAP={:.3f}%".format(result_dict["mAP"])
+            acc_str += ", mAP={:.3f}%".format(result["mAP"])
 
     # add the result to the result dict
     final_results[name] = result


### PR DESCRIPTION
Running `./run_and_time.sh tf ssd-mobilenet cpu` on 50 images:
- before the fix:
```
TestScenario.Offline qps=0.84, mean=1.1605, time=2.394, acc=92.222%, mAP=0.258%, queries=2, tiles=50.0:1.1605,80.0:1.1930,90.0:1.2038,95.0:1.2092,99.0:1.2135,99.9:1.2145
```
- after the fix:
```
$ ./run_and_time.sh tf ssd-mobilenet cpu
...
TestScenario.Offline qps=0.43, mean=2.3084, time=4.647, acc=92.222%, mAP=25.839%, queries=2, tiles=50.0:2.3084,80.0:2.4589,90.0:2.5091,95.0:2.5342,99.0:2.5542,99.9:2.5587
```