### PR TITLE
proposed bugfix for issue #323

### DIFF
--- a/v0.5/classification_and_detection/python/coco.py
+++ b/v0.5/classification_and_detection/python/coco.py
@@ -197,7 +197,7 @@ class PostProcessCoco:
             pp = []
             for detection in detections:
                 pp.append({"image_id": int(detection[0]),
-                           "image_loc": ds.get_item_loc("{:012d}.jpg".format(int(detection[0]))),
+                           "image_loc": ds.get_item_loc("val2017/{:012d}.jpg".format(int(detection[0]))),
                            "category_id": int(detection[6]),
                            "bbox": [float(detection[1]), float(detection[2]),
                                     float(detection[3]), float(detection[4])],

--- a/v0.5/classification_and_detection/python/coco.py
+++ b/v0.5/classification_and_detection/python/coco.py
@@ -104,7 +104,7 @@ class Coco(dataset.Dataset):
         return img, self.label_list[nr]
 
     def get_item_loc(self, nr):
-        src = os.path.join(self.data_path, self.image_list[nr])
+        src = os.path.join(self.data_path, nr)
         return src
 
 
@@ -197,7 +197,7 @@ class PostProcessCoco:
             pp = []
             for detection in detections:
                 pp.append({"image_id": int(detection[0]),
-                           "image_loc": ds.get_item_loc(image_ids[idx]),
+                           "image_loc": ds.get_item_loc("{:012d}.jpg".format(int(detection[0]))),
                            "category_id": int(detection[6]),
                            "bbox": [float(detection[1]), float(detection[2]),
                                     float(detection[3]), float(detection[4])],


### PR DESCRIPTION
https://github.com/mlperf/inference/issues/323

since in the loops that creates the output log there is no more the "idx" loop variable, i recreate the image filename using the image ID (names in coco are 12 digits with leading zeros and jpg extension). 
To be able to actually use the generated filename I needed to modify the get_item_loc function to append with the given filename string to the path and no more perform a lookup in the self.image_list variable to get that filename.
