### PR TITLE
https://github.com/mlperf/inference_policies/issues/41 enable accurac…

### DIFF
--- a/loadgen/bindings/python_api.cc
+++ b/loadgen/bindings/python_api.cc
@@ -226,7 +226,9 @@ PYBIND11_MODULE(mlperf_loadgen, m) {
       .def_readwrite("qsl_rng_seed", &TestSettings::qsl_rng_seed)
       .def_readwrite("sample_index_rng_seed",
                      &TestSettings::sample_index_rng_seed)
-      .def_readwrite("schedule_rng_seed", &TestSettings::schedule_rng_seed);
+      .def_readwrite("schedule_rng_seed", &TestSettings::schedule_rng_seed)
+      .def_readwrite("acc_log_rng_seed", &TestSettings::acc_log_rng_seed)
+      .def_readwrite("acc_log_probability", &TestSettings::acc_log_probability);
 
   pybind11::enum_<LoggingMode>(m, "LoggingMode")
       .value("AsyncPoll", LoggingMode::AsyncPoll)

--- a/loadgen/test_settings.h
+++ b/loadgen/test_settings.h
@@ -201,7 +201,7 @@ struct TestSettings {
 
   // ==================================
   /// \name Random number generation
-  /// There are 3 separate seeds, so each dimension can be changed
+  /// There are 4 separate seeds, so each dimension can be changed
   /// independently.
   /**@{*/
   /// \brief Affects which subset of samples from the QSL are chosen for
@@ -214,6 +214,13 @@ struct TestSettings {
   /// \details Different seeds will appear to "jitter" the queries
   /// differently in time, but should not affect the average issued QPS.
   uint64_t schedule_rng_seed = 0;
+  /// \brief Affects which samples have their query returns logged to the
+  /// accuracy log in performance mode.
+  uint64_t acc_log_rng_seed = 0;
+
+  /// \brief Probability of the query response of a sample being logged to the accuracy
+  /// log in performance mode
+  double acc_log_probability = 0.0;
   /**@}*/
 };
 

--- a/loadgen/test_settings_internal.cc
+++ b/loadgen/test_settings_internal.cc
@@ -34,7 +34,9 @@ TestSettingsInternal::TestSettingsInternal(
       min_sample_count(0),
       qsl_rng_seed(requested.qsl_rng_seed),
       sample_index_rng_seed(requested.sample_index_rng_seed),
-      schedule_rng_seed(requested.schedule_rng_seed) {
+      schedule_rng_seed(requested.schedule_rng_seed),
+      acc_log_rng_seed(requested.acc_log_rng_seed),
+      acc_log_probability(requested.acc_log_probability) {
   // Target QPS, target latency, and max_async_queries.
   switch (requested.scenario) {
     case TestScenario::SingleStream:

--- a/loadgen/test_settings_internal.h
+++ b/loadgen/test_settings_internal.h
@@ -69,6 +69,8 @@ struct TestSettingsInternal {
   uint64_t qsl_rng_seed;
   uint64_t sample_index_rng_seed;
   uint64_t schedule_rng_seed;
+  uint64_t acc_log_rng_seed;
+  double acc_log_probability;
 };
 
 }  // namespace loadgen


### PR DESCRIPTION
…y logging in performance mode using TestSettings parameters acc_log_probability and acc_log_rng_seed