### PR TITLE
https://github.com/mlperf/inference_policies/issues/41 round2

### DIFF
--- a/loadgen/bindings/python_api.cc
+++ b/loadgen/bindings/python_api.cc
@@ -227,8 +227,10 @@ PYBIND11_MODULE(mlperf_loadgen, m) {
       .def_readwrite("sample_index_rng_seed",
                      &TestSettings::sample_index_rng_seed)
       .def_readwrite("schedule_rng_seed", &TestSettings::schedule_rng_seed)
-      .def_readwrite("acc_log_rng_seed", &TestSettings::acc_log_rng_seed)
-      .def_readwrite("acc_log_probability", &TestSettings::acc_log_probability);
+      .def_readwrite("accuracy_log_rng_seed",
+                     &TestSettings::accuracy_log_rng_seed)
+      .def_readwrite("accuracy_log_probability",
+                     &TestSettings::accuracy_log_probability);
 
   pybind11::enum_<LoggingMode>(m, "LoggingMode")
       .value("AsyncPoll", LoggingMode::AsyncPoll)

--- a/loadgen/bindings/python_api.cc
+++ b/loadgen/bindings/python_api.cc
@@ -226,7 +226,9 @@ PYBIND11_MODULE(mlperf_loadgen, m) {
       .def_readwrite("qsl_rng_seed", &TestSettings::qsl_rng_seed)
       .def_readwrite("sample_index_rng_seed",
                      &TestSettings::sample_index_rng_seed)
-      .def_readwrite("schedule_rng_seed", &TestSettings::schedule_rng_seed);
+      .def_readwrite("schedule_rng_seed", &TestSettings::schedule_rng_seed)
+      .def_readwrite("acc_log_rng_seed", &TestSettings::acc_log_rng_seed)
+      .def_readwrite("acc_log_probability", &TestSettings::acc_log_probability);
 
   pybind11::enum_<LoggingMode>(m, "LoggingMode")
       .value("AsyncPoll", LoggingMode::AsyncPoll)

--- a/loadgen/loadgen.cc
+++ b/loadgen/loadgen.cc
@@ -44,19 +44,23 @@ struct SampleMetadata;
 class QueryMetadata;
 
 /// \brief Every query and sample within a call to StartTest gets a unique
-/// sequence id for easy cross reference.
+/// sequence id for easy cross reference, and a random number which is used to
+/// determine accuracy logging when it is enabled.
 struct SequenceGen {
   uint64_t NextQueryId() { return query_id++; }
   uint64_t NextSampleId() { return sample_id++; }
   uint64_t CurrentSampleId() { return sample_id; }
-  double NextAccLogRng() { return acc_log_dist(acc_log_rng); }
-  void InitAccLogRng(uint64_t acc_log_rng_seed) { acc_log_rng = std::mt19937(acc_log_rng_seed); }
+  double NextAccLogRng() { return accuracy_log_dist(accuracy_log_rng); }
+  void InitAccLogRng(uint64_t accuracy_log_rng_seed) {
+    accuracy_log_rng = std::mt19937(accuracy_log_rng_seed);
+  }
 
  private:
   uint64_t query_id = 0;
   uint64_t sample_id = 0;
-  std::mt19937 acc_log_rng;
-  std::uniform_real_distribution<double> acc_log_dist = std::uniform_real_distribution<double>(0,1);
+  std::mt19937 accuracy_log_rng;
+  std::uniform_real_distribution<double> accuracy_log_dist =
+      std::uniform_real_distribution<double>(0, 1);
 };
 
 /// \brief A random set of samples in the QSL that should fit in RAM when
@@ -80,7 +84,7 @@ struct SampleMetadata {
   QueryMetadata* query_metadata;
   uint64_t sequence_id;
   QuerySampleIndex sample_index;
-  double acc_log_val;
+  double accuracy_log_val;
 };
 
 /// \brief Maintains data and timing info for a query and all its samples.
@@ -177,8 +181,8 @@ struct DurationGeneratorNs {
 template <TestScenario scenario, TestMode mode>
 struct ResponseDelegateDetailed : public ResponseDelegate {
   std::atomic<size_t> queries_completed{0};
-  double acc_log_offset = 0.0f;
-  double acc_log_prob = 0.0f;
+  double accuracy_log_offset = 0.0f;
+  double accuracy_log_prob = 0.0f;
 
   void SampleComplete(SampleMetadata* sample, QuerySampleResponse* response,
                       PerfClock::time_point complete_begin_time) override {
@@ -187,10 +191,12 @@ struct ResponseDelegateDetailed : public ResponseDelegate {
     // For some reason, using std::unique_ptr<std::vector> wasn't moving
     // into the lambda; even with C++14.
     std::vector<uint8_t>* sample_data_copy = nullptr;
-    double acc_log_val = sample->acc_log_val + acc_log_offset < 1.0 ?
-        sample->acc_log_val + acc_log_offset :
-        sample->acc_log_val + acc_log_offset - 1.0;
-    if (mode == TestMode::AccuracyOnly || acc_log_val <= acc_log_prob ) {
+    double accuracy_log_val =
+        sample->accuracy_log_val + accuracy_log_offset < 1.0
+            ? sample->accuracy_log_val + accuracy_log_offset
+            : sample->accuracy_log_val + accuracy_log_offset - 1.0;
+    if (mode == TestMode::AccuracyOnly ||
+        accuracy_log_val <= accuracy_log_prob) {
       // TODO: Verify accuracy with the data copied here.
       uint8_t* src_begin = reinterpret_cast<uint8_t*>(response->data);
       uint8_t* src_end = src_begin + response->size;
@@ -580,10 +586,12 @@ PerformanceResult IssueQueries(SystemUnderTest* sut,
                                SequenceGen* sequence_gen) {
   GlobalLogger().RestartLatencyRecording(sequence_gen->CurrentSampleId());
   ResponseDelegateDetailed<scenario, mode> response_logger;
-  std::uniform_real_distribution<double> acc_log_offset_dist = std::uniform_real_distribution<double>(0.0,1.0);
-  std::mt19937 acc_log_offset_rng(settings.acc_log_rng_seed);
-  response_logger.acc_log_offset = acc_log_offset_dist(acc_log_offset_rng);
-  response_logger.acc_log_prob = settings.acc_log_probability;
+  std::uniform_real_distribution<double> accuracy_log_offset_dist =
+      std::uniform_real_distribution<double>(0.0, 1.0);
+  std::mt19937 accuracy_log_offset_rng(settings.accuracy_log_rng_seed);
+  response_logger.accuracy_log_offset =
+      accuracy_log_offset_dist(accuracy_log_offset_rng);
+  response_logger.accuracy_log_prob = settings.accuracy_log_probability;
 
   std::vector<QueryMetadata> queries = GenerateQueries<scenario, mode>(
       settings, loaded_sample_set, sequence_gen, &response_logger);

--- a/loadgen/loadgen.cc
+++ b/loadgen/loadgen.cc
@@ -99,7 +99,8 @@ class QueryMetadata {
         wait_count_(query_sample_indices.size()) {
     samples_.reserve(query_sample_indices.size());
     for (QuerySampleIndex qsi : query_sample_indices) {
-      samples_.push_back({this, sequence_gen->NextSampleId(), qsi, sequence_gen->NextAccLogRng()});
+      samples_.push_back({this, sequence_gen->NextSampleId(), qsi,
+                          sequence_gen->NextAccLogRng()});
     }
     query_to_send.reserve(query_sample_indices.size());
     for (auto& s : samples_) {

--- a/loadgen/test_settings.h
+++ b/loadgen/test_settings.h
@@ -201,7 +201,7 @@ struct TestSettings {
 
   // ==================================
   /// \name Random number generation
-  /// There are 3 separate seeds, so each dimension can be changed
+  /// There are 4 separate seeds, so each dimension can be changed
   /// independently.
   /**@{*/
   /// \brief Affects which subset of samples from the QSL are chosen for
@@ -214,6 +214,13 @@ struct TestSettings {
   /// \details Different seeds will appear to "jitter" the queries
   /// differently in time, but should not affect the average issued QPS.
   uint64_t schedule_rng_seed = 0;
+  /// \brief Affects which samples have their query returns logged to the
+  /// accuracy log in performance mode.
+  uint64_t acc_log_rng_seed = 0;
+
+  /// \brief Probability of the query response of a sample being logged to the accuracy
+  /// log in performance mode
+  double acc_log_probability = 0.0;
   /**@}*/
 };
 

--- a/loadgen/test_settings.h
+++ b/loadgen/test_settings.h
@@ -216,11 +216,11 @@ struct TestSettings {
   uint64_t schedule_rng_seed = 0;
   /// \brief Affects which samples have their query returns logged to the
   /// accuracy log in performance mode.
-  uint64_t acc_log_rng_seed = 0;
+  uint64_t accuracy_log_rng_seed = 0;
 
   /// \brief Probability of the query response of a sample being logged to the accuracy
   /// log in performance mode
-  double acc_log_probability = 0.0;
+  double accuracy_log_probability = 0.0;
   /**@}*/
 };
 

--- a/loadgen/test_settings_internal.cc
+++ b/loadgen/test_settings_internal.cc
@@ -34,7 +34,9 @@ TestSettingsInternal::TestSettingsInternal(
       min_sample_count(0),
       qsl_rng_seed(requested.qsl_rng_seed),
       sample_index_rng_seed(requested.sample_index_rng_seed),
-      schedule_rng_seed(requested.schedule_rng_seed) {
+      schedule_rng_seed(requested.schedule_rng_seed),
+      acc_log_rng_seed(requested.acc_log_rng_seed),
+      acc_log_probability(requested.acc_log_probability) {
   // Target QPS, target latency, and max_async_queries.
   switch (requested.scenario) {
     case TestScenario::SingleStream:

--- a/loadgen/test_settings_internal.cc
+++ b/loadgen/test_settings_internal.cc
@@ -35,8 +35,8 @@ TestSettingsInternal::TestSettingsInternal(
       qsl_rng_seed(requested.qsl_rng_seed),
       sample_index_rng_seed(requested.sample_index_rng_seed),
       schedule_rng_seed(requested.schedule_rng_seed),
-      acc_log_rng_seed(requested.acc_log_rng_seed),
-      acc_log_probability(requested.acc_log_probability) {
+      accuracy_log_rng_seed(requested.accuracy_log_rng_seed),
+      accuracy_log_probability(requested.accuracy_log_probability) {
   // Target QPS, target latency, and max_async_queries.
   switch (requested.scenario) {
     case TestScenario::SingleStream:
@@ -189,6 +189,8 @@ void LogRequestedTestSettings(const TestSettings &s) {
     detail("qsl_rng_seed : ", s.qsl_rng_seed);
     detail("sample_index_rng_seed : ", s.sample_index_rng_seed);
     detail("schedule_rng_seed : ", s.schedule_rng_seed);
+    detail("accuracy_log_rng_seed : ", s.accuracy_log_rng_seed);
+    detail("accuracy_log_probability : ", s.accuracy_log_probability);
 
     detail("");
   });
@@ -216,6 +218,8 @@ void TestSettingsInternal::LogEffectiveSettings() const {
     detail("qsl_rng_seed : ", s.qsl_rng_seed);
     detail("sample_index_rng_seed : ", s.sample_index_rng_seed);
     detail("schedule_rng_seed : ", s.schedule_rng_seed);
+    detail("accuracy_log_rng_seed : ", s.accuracy_log_rng_seed);
+    detail("accuracy_log_probability : ", s.accuracy_log_probability);
   });
 }
 
@@ -236,6 +240,8 @@ void TestSettingsInternal::LogSummary(AsyncSummary &summary) const {
   summary("qsl_rng_seed : ", qsl_rng_seed);
   summary("sample_index_rng_seed : ", sample_index_rng_seed);
   summary("schedule_rng_seed : ", schedule_rng_seed);
+  summary("accuracy_log_rng_seed : ", accuracy_log_rng_seed);
+  summary("accuracy_log_probability : ", accuracy_log_probability);
 }
 
 }  // namespace loadgen

--- a/loadgen/test_settings_internal.h
+++ b/loadgen/test_settings_internal.h
@@ -69,6 +69,8 @@ struct TestSettingsInternal {
   uint64_t qsl_rng_seed;
   uint64_t sample_index_rng_seed;
   uint64_t schedule_rng_seed;
+  uint64_t acc_log_rng_seed;
+  double acc_log_probability;
 };
 
 }  // namespace loadgen

--- a/loadgen/test_settings_internal.h
+++ b/loadgen/test_settings_internal.h
@@ -69,8 +69,8 @@ struct TestSettingsInternal {
   uint64_t qsl_rng_seed;
   uint64_t sample_index_rng_seed;
   uint64_t schedule_rng_seed;
-  uint64_t acc_log_rng_seed;
-  double acc_log_probability;
+  uint64_t accuracy_log_rng_seed;
+  double accuracy_log_probability;
 };
 
 }  // namespace loadgen


### PR DESCRIPTION
To address Brian's concerns, we no longer generate random numbers in SampleComplete(), since the rng is not thread-safe. Instead of passing a flag through SampleMetadata as per Brian's proposal, we pass a random number that is now generated in GenerateQueries(). Then in SampleComplete(), we offset the random number by another random number in ResponseDelegate and check against target interval based on acc_log_probability. This prevents a SUT from simply reading SampleMetadata to determine which samples are being logged.