### PR TITLE
fix build issue on windows

### DIFF
--- a/loadgen/CMakeLists.txt
+++ b/loadgen/CMakeLists.txt
@@ -8,7 +8,9 @@ set(mlperf_loadgen_VERSION_MINOR 5)
 message("mlperf_loadgen v${mlperf_loadgen_VERSION_MAJOR}.${mlperf_loadgen_VERSION_MINOR}")
 
 # Set build options. NB: CXX_STANDARD is supported since CMake 3.1.
+if (NOT MSVC)
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O2 -W -Wall")
+endif()
 message(STATUS "Using C++ compiler flags: ${CMAKE_CXX_FLAGS}")
 set(CMAKE_CXX_STANDARD "14")
 message(STATUS "Using C++ standard: ${CMAKE_CXX_STANDARD}")

--- a/loadgen/loadgen.cc
+++ b/loadgen/loadgen.cc
@@ -745,6 +745,13 @@ struct PerformanceSummary {
   PercentileEntry latency_percentiles[6] = {{.50}, {.90}, {.95},
                                             {.97}, {.99}, {.999}};
 
+  PerformanceSummary::PerformanceSummary(
+      const std::string& sut_name_arg,
+      const TestSettingsInternal& settings_arg,
+      const PerformanceResult& pr_arg)
+      : sut_name(sut_name_arg), settings(settings_arg), pr(pr_arg) {
+  };
+
   void ProcessLatencies();
 
   bool MinDurationMet(std::string* recommendation);


### PR DESCRIPTION
msvc is fails to compile loadgen.cc.
Some issue about the construction of PerformanceSummary around
```PercentileEntry target_latency_percentile{settings.target_latency_percentile};```.
Adding a constructor for PerformanceSummary.
I think the constructor is good anyway because ```TestSettingsInternal settings``` does not have a default constructor so if one would instantiate PerformanceSummary without settings things might not be initialized.
