### PR TITLE
Fix the bug with extra qualification ‘mlperf::loadgen::PerformanceSum…

### DIFF
--- a/loadgen/loadgen.cc
+++ b/loadgen/loadgen.cc
@@ -745,7 +745,7 @@ struct PerformanceSummary {
   PercentileEntry latency_percentiles[6] = {{.50}, {.90}, {.95},
                                             {.97}, {.99}, {.999}};
 
-  PerformanceSummary::PerformanceSummary(
+  PerformanceSummary(
       const std::string& sut_name_arg,
       const TestSettingsInternal& settings_arg,
       const PerformanceResult& pr_arg)


### PR DESCRIPTION
…mary:: for gcc

labuser@dalibeast06:~/Work/Projects/MlPerf/inference/loadgen/build$ make
Scanning dependencies of target mlperf_loadgen
[ 12%] Building CXX object CMakeFiles/mlperf_loadgen.dir/loadgen.cc.o
/home/labuser/Work/Projects/MlPerf/inference/loadgen/loadgen.cc:748:3: error: extra qualification ‘mlperf::loadgen::PerformanceSummary::’ on member ‘PerformanceSummary’ [-fpermissive]
   PerformanceSummary::PerformanceSummary(
   ^
CMakeFiles/mlperf_loadgen.dir/build.make:86: recipe for target 'CMakeFiles/mlperf_loadgen.dir/loadgen.cc.o' failed
make[2]: *** [CMakeFiles/mlperf_loadgen.dir/loadgen.cc.o] Error 1
CMakeFiles/Makefile2:67: recipe for target 'CMakeFiles/mlperf_loadgen.dir/all' failed
make[1]: *** [CMakeFiles/mlperf_loadgen.dir/all] Error 2
Makefile:127: recipe for target 'all' failed
make: *** [all] Error 2
labuser@dalibeast06:~/Work/Projects/MlPerf/inference/loadgen/build$

labuser@dalibeast06:~/Work/Projects/MlPerf/inference/loadgen/build$ c++ --version
c++ (Ubuntu 5.4.0-6ubuntu1~16.04.10) 5.4.0 20160609
Copyright (C) 2015 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

labuser@dalibeast06:~/Work/Projects/MlPerf/inference/loadgen/build$