### PR TITLE
add support for loading mlperf rules parameters from config file

### DIFF
--- a/loadgen/bindings/python_api.cc
+++ b/loadgen/bindings/python_api.cc
@@ -234,7 +234,8 @@ PYBIND11_MODULE(mlperf_loadgen, m) {
       .def_readwrite("accuracy_log_rng_seed",
                      &TestSettings::accuracy_log_rng_seed)
       .def_readwrite("accuracy_log_probability",
-                     &TestSettings::accuracy_log_probability);
+                     &TestSettings::accuracy_log_probability)
+      .def("FromConfig", &TestSettings::FromConfig, "FromConfig.");
 
   pybind11::enum_<LoggingMode>(m, "LoggingMode")
       .value("AsyncPoll", LoggingMode::AsyncPoll)

--- a/loadgen/loadgen.cc
+++ b/loadgen/loadgen.cc
@@ -20,8 +20,10 @@ limitations under the License.
 #include <cstring>
 #include <fstream>
 #include <future>
+#include <map>
 #include <queue>
 #include <random>
+#include <sstream>
 #include <string>
 #include <thread>
 #include <vector>
@@ -1486,6 +1488,111 @@ void QuerySamplesComplete(QuerySampleResponse* responses,
     loadgen::QueryMetadata* query = sample->query_metadata;
     query->response_delegate->SampleComplete(sample, response, timestamp);
   }
+}
+
+int TestSettings::FromConfig(const std::string &path, const std::string &model,
+                             const std::string &scenario) {
+  std::map<std::string, size_t> kv;
+
+  // lookup key/value pairs from config
+  auto lookupkv = [&](const std::string &model, const std::string &scenario,
+                      const std::string &key, size_t &val) {
+    std::map<std::string, size_t>::iterator it;
+
+    // lookup exact key first
+    it = kv.find(model + scenario + "." + key);
+    if (it != kv.end()) {
+      val = it->second;
+      return true;
+    }
+    // lookup key with model wildcard first
+    it = kv.find("*." + scenario + "." + key);
+    if (it != kv.end()) {
+      val = it->second;
+      return true;
+    }
+    return false;
+  };
+
+  // dirt simple config parser
+  std::ifstream fss(path);
+  std::string line;
+  int line_nr = 0;
+  int errors = 0;
+  if (!fss.is_open()) {
+    LogDetail([p = path](AsyncDetail & detail) {
+      detail.Error("can't open ", p);
+    });
+    return -ENOENT;
+  }
+  while (std::getline(fss, line)) {
+    line_nr++;
+    std::istringstream iss(line);
+    std::string s, k;
+    int state = 0;
+    while (iss >> s) {
+      if (s == "#" && state != 2) {
+        // done with this line
+        break;
+      }
+      if (state == 2) {
+        // got key and value
+        char *end;
+        kv[k] = std::strtol(s.c_str(), &end, 10);
+      }
+      if (state == 1 && s != "=") {
+        errors++;
+        LogDetail([l = line_nr](AsyncDetail & detail) {
+          detail.Error("error in line ", l);
+        });
+        break;
+      }
+      if (state == 0) k = s;
+      state++;
+    }
+  }
+  if (errors != 0) return -EINVAL;
+
+  // set final values in TestSettings
+  size_t val;
+
+  // keys that apply to all
+  if (lookupkv(model, scenario, "min_duration", val)) min_duration_ms = val;
+  if (lookupkv(model, scenario, "max_duration", val)) max_duration_ms = val;
+  if (lookupkv(model, scenario, "min_query_count", val)) min_query_count = val;
+  if (lookupkv(model, scenario, "max_query_count", val)) max_query_count = val;
+
+  // keys that apply to SingleStream
+  if (lookupkv(model, "SingleStream", "target_latency_percentile", val))
+    single_stream_target_latency_percentile = double(val) / 100.0;
+  if (lookupkv(model, "SingleStream", "target_latency", val))
+    single_stream_expected_latency_ns = val * 1000 * 1000;
+
+  // keys that apply to MultiStream
+  if (lookupkv(model, "MultiStream", "target_latency_percentile", val))
+    multi_stream_target_latency_percentile = double(val) / 100.0;
+  if (lookupkv(model, "MultiStream", "target_qps", val))
+    multi_stream_target_qps = double(val);
+  if (lookupkv(model, "MultiStream", "samples_per_query", val))
+    multi_stream_samples_per_query = int(val);
+  if (lookupkv(model, "MultiStream", "max_async_queries", val))
+    multi_stream_max_async_queries = int(val);
+
+  // keys that apply to Server
+  if (lookupkv(model, "Server", "target_latency_percentile", val))
+    server_target_latency_percentile = double(val) / 100.0;
+  if (lookupkv(model, "Server", "target_latency", val))
+    server_target_latency_ns = val * 1000 * 1000;
+  if (lookupkv(model, "Server", "coalesce_queries", val))
+    server_coalesce_queries = (val == 0) ? false : true;
+  if (lookupkv(model, "Server", "target_qps", val))
+    server_target_qps = double(val);
+
+  // keys that apply to Offline
+  if (lookupkv(model, "Offline", "target_qps", val))
+    offline_expected_qps = double(val);
+
+  return 0;
 }
 
 }  // namespace mlperf

--- a/loadgen/test_settings.h
+++ b/loadgen/test_settings.h
@@ -232,7 +232,12 @@ struct TestSettings {
   /// \brief Probability of the query response of a sample being logged to the accuracy
   /// log in performance mode
   double accuracy_log_probability = 0.0;
+
+  /// \brief Load mlperf parameter config from file.
+  int FromConfig(const std::string &config_file, 
+      const std::string &model, const std::string &mode);
   /**@}*/
+
 };
 
 ///

--- a/loadgen/test_settings.h
+++ b/loadgen/test_settings.h
@@ -229,15 +229,15 @@ struct TestSettings {
   /// accuracy log in performance mode.
   uint64_t accuracy_log_rng_seed = 0;
 
-  /// \brief Probability of the query response of a sample being logged to the accuracy
+  /// \brief Probability of the query response of a sample being logged to the
+  /// accuracy
   /// log in performance mode
   double accuracy_log_probability = 0.0;
 
   /// \brief Load mlperf parameter config from file.
-  int FromConfig(const std::string &config_file, 
-      const std::string &model, const std::string &mode);
+  int FromConfig(const std::string &config_file, const std::string &model,
+                 const std::string &mode);
   /**@}*/
-
 };
 
 ///

--- a/loadgen/test_settings_internal.cc
+++ b/loadgen/test_settings_internal.cc
@@ -12,11 +12,11 @@ limitations under the License.
 
 #include <fstream>
 #include <map>
-#include <string>
 #include <sstream>
+#include <string>
 
-#include "test_settings_internal.h"
 #include "logging.h"
+#include "test_settings_internal.h"
 #include "utils.h"
 
 namespace mlperf {
@@ -63,8 +63,10 @@ TestSettingsInternal::TestSettingsInternal(
       if (requested.server_target_qps >= 0.0) {
         target_qps = requested.server_target_qps;
       } else {
-        LogDetail([server_target_qps = requested.server_target_qps,
-                   target_qps = target_qps](AsyncDetail &detail) {
+        LogDetail([
+          server_target_qps = requested.server_target_qps,
+          target_qps = target_qps
+        ](AsyncDetail & detail) {
           detail.Error("Invalid value for server_target_qps requested.",
                        "requested", server_target_qps, "using", target_qps);
         });
@@ -73,15 +75,16 @@ TestSettingsInternal::TestSettingsInternal(
           std::chrono::nanoseconds(requested.server_target_latency_ns);
       max_async_queries =
           std::numeric_limits<decltype(max_async_queries)>::max();
-      target_latency_percentile =
-          requested.server_target_latency_percentile;
+      target_latency_percentile = requested.server_target_latency_percentile;
       break;
     case TestScenario::Offline:
       if (requested.offline_expected_qps >= 0.0) {
         target_qps = requested.offline_expected_qps;
       } else {
-        LogDetail([offline_expected_qps = requested.offline_expected_qps,
-                   target_qps = target_qps](AsyncDetail &detail) {
+        LogDetail([
+          offline_expected_qps = requested.offline_expected_qps,
+          target_qps = target_qps
+        ](AsyncDetail & detail) {
           detail.Error("Invalid value for offline_expected_qps requested.",
                        "requested", offline_expected_qps, "using", target_qps);
         });
@@ -201,7 +204,7 @@ void LogRequestedTestSettings(const TestSettings &s) {
 }
 
 void TestSettingsInternal::LogEffectiveSettings() const {
-  LogDetail([s = *this](AsyncDetail &detail) {
+  LogDetail([s = *this](AsyncDetail & detail) {
     detail("");
     detail("Effective Settings:");
 
@@ -250,14 +253,14 @@ void TestSettingsInternal::LogSummary(AsyncSummary &summary) const {
 
 }  // namespace loadgen
 
-
 int TestSettings::FromConfig(const std::string &path, const std::string &model,
                              const std::string &scenario) {
   std::map<std::string, std::string> kv;
 
   // lookup key/value pairs from config
   auto lookupkv = [&](const std::string &model, const std::string &scenario,
-                      const std::string &key, size_t* val_l, double* val_d, double multiplier=1.0) {
+                      const std::string &key, size_t *val_l, double *val_d,
+                      double multiplier = 1.0) {
     std::map<std::string, std::string>::iterator it;
     std::string found;
     // lookup exact key first
@@ -265,8 +268,8 @@ int TestSettings::FromConfig(const std::string &path, const std::string &model,
     if (it != kv.end()) {
       found = it->second;
     } else {
-    // lookup key with model wildcard
-    it = kv.find("*." + scenario + "." + key);
+      // lookup key with model wildcard
+      it = kv.find("*." + scenario + "." + key);
       if (it != kv.end()) {
         found = it->second;
       } else {
@@ -303,7 +306,7 @@ int TestSettings::FromConfig(const std::string &path, const std::string &model,
       if (state == 2) {
         // got key and value
         const char *start = s.c_str();
-        char *stop; 
+        char *stop;
         (void)strtoul(start, &stop, 0);
         if (start + s.size() == stop) {
           kv[k] = s;
@@ -319,7 +322,6 @@ int TestSettings::FromConfig(const std::string &path, const std::string &model,
           detail.Error("error in line ", l);
         });
         break;
-
       }
       if (state == 1 && s != "=") {
         errors++;
@@ -335,7 +337,7 @@ int TestSettings::FromConfig(const std::string &path, const std::string &model,
   if (errors != 0) return -EINVAL;
 
   size_t val;
-  
+
   // keys that apply to all scenarios
   lookupkv(model, scenario, "min_duration", &min_duration_ms, nullptr);
   lookupkv(model, scenario, "max_duration", &max_duration_ms, nullptr);
@@ -343,20 +345,26 @@ int TestSettings::FromConfig(const std::string &path, const std::string &model,
   lookupkv(model, scenario, "max_query_count", &max_query_count, nullptr);
 
   // keys that apply to SingleStream
-  lookupkv(model, "SingleStream", "target_latency_percentile", nullptr, &single_stream_target_latency_percentile, 0.01);
-  lookupkv(model, "SingleStream", "target_latency", &single_stream_expected_latency_ns, nullptr, 1000*1000);
+  lookupkv(model, "SingleStream", "target_latency_percentile", nullptr,
+           &single_stream_target_latency_percentile, 0.01);
+  lookupkv(model, "SingleStream", "target_latency",
+           &single_stream_expected_latency_ns, nullptr, 1000 * 1000);
 
   // keys that apply to MultiStream
-  lookupkv(model, "MultiStream", "target_latency_percentile", nullptr, &multi_stream_target_latency_percentile, 0.01);
-  lookupkv(model, "MultiStream", "target_qps", nullptr, &multi_stream_target_qps);
+  lookupkv(model, "MultiStream", "target_latency_percentile", nullptr,
+           &multi_stream_target_latency_percentile, 0.01);
+  lookupkv(model, "MultiStream", "target_qps", nullptr,
+           &multi_stream_target_qps);
   if (lookupkv(model, "MultiStream", "samples_per_query", &val, nullptr))
     multi_stream_samples_per_query = int(val);
   if (lookupkv(model, "MultiStream", "max_async_queries", &val, nullptr))
     multi_stream_max_async_queries = int(val);
 
   // keys that apply to Server
-  lookupkv(model, "Server", "target_latency_percentile", nullptr, &server_target_latency_percentile, 0.01);
-  lookupkv(model, "Server", "target_latency", &server_target_latency_ns, nullptr, 1000*1000);
+  lookupkv(model, "Server", "target_latency_percentile", nullptr,
+           &server_target_latency_percentile, 0.01);
+  lookupkv(model, "Server", "target_latency", &server_target_latency_ns,
+           nullptr, 1000 * 1000);
   lookupkv(model, "Server", "target_qps", nullptr, &server_target_qps);
   if (lookupkv(model, "Server", "coalesce_queries", &val, nullptr))
     server_coalesce_queries = (val == 0) ? false : true;

--- a/v0.5/classification_and_detection/README.md
+++ b/v0.5/classification_and_detection/README.md
@@ -179,9 +179,9 @@ During development running the full benchmark is unpractical. Some options to he
 
 So if you want to tune for example Server mode, try:
 ```
-./run_local.sh tf resnet50 gpu --count 100 --time 60 --scenario Server --qps 200 --max-latency 0.2
+./run_local.sh tf resnet50 gpu --count 100 --time 60 --scenario Server --qps 200 --max-latency 0.1
 or
-./run_local.sh tf ssd-mobilenet gpu --count 100 --time 60 --scenario Server --qps 100 --max-latency 0.2
+./run_local.sh tf ssd-mobilenet gpu --count 100 --time 60 --scenario Server --qps 100 --max-latency 0.1
 
 ```
 
@@ -194,19 +194,21 @@ If you want run with accuracy pass, try:
 ### Usage
 ```
 usage: main.py [-h]
+    [--config ../mlperf.conf]
     [--dataset {imagenet,imagenet_mobilenet,coco,coco-300,coco-1200,coco-1200-onnx,coco-1200-pt,coco-1200-tf}]
     --dataset-path DATASET_PATH [--dataset-list DATASET_LIST]
     [--data-format {NCHW,NHWC}]
     [--profile {defaults,resnet50-tf,resnet50-onnxruntime,mobilenet-tf,mobilenet-onnxruntime,ssd-mobilenet-tf,ssd-mobilenet-onnxruntime,ssd-resnet34-tf,ssd-resnet34-pytorch,ssd-resnet34-onnxruntime}]
     [--scenario list of SingleStream,MultiStream,Server,Offline]
-    [--queries-single QUERIES_SINGLE]
-    [--queries-offline QUERIES_OFFLINE]
-    [--queries-multi QUERIES_MULTI] [--max-batchsize MAX_BATCHSIZE]
+    [--max-batchsize MAX_BATCHSIZE]
     --model MODEL [--output OUTPUT] [--inputs INPUTS]
     [--outputs OUTPUTS] [--backend BACKEND] [--threads THREADS]
     [--time TIME] [--count COUNT] [--qps QPS]
     [--max-latency MAX_LATENCY] [--cache CACHE] [--accuracy]
 ```
+
+```--config```
+the mlperf config file to use, defaults to v0.5/mlperf.conf
 
 ```--dataset```
 use the specified dataset. Currently we only support ImageNet.
@@ -249,15 +251,6 @@ Expected QPS.
 
 ```--max-latency MAX_LATENCY```
 comma separated list of which latencies (in seconds) we try to reach in the 99 percentile (deault: 0.01,0.05,0.100).
-
-```--queries-single QUERIES_SINGLE```
-queries to use for SingleStream scenario (default: 1024).
-
-```--queries-offline QUERIES_OFFLINE```
-queries to use for Offline scenario (default: 24576).
-
-```--queries-multi QUERIES_MULTI```
-queries to use for MultiStream scenario (default: 24576).
 
 ```--max-batchsize MAX_BATCHSIZE```
 maximum batchsize we generate to backend (default: 128).

--- a/v0.5/classification_and_detection/python/main.py
+++ b/v0.5/classification_and_detection/python/main.py
@@ -516,7 +516,7 @@ def main():
     if not last_timeing:
         last_timeing = runner.result_timing
     if args.accuracy:
-        post_proc.finalize(result_dict, ds, output_dir=os.path.dirname(args.output))
+        post_proc.finalize(result_dict, ds, output_dir=args.output)
     add_results(final_results, "{}".format(scenario),
                 result_dict, last_timeing, time.time() - ds.last_loaded, args.accuracy)
 
@@ -528,7 +528,7 @@ def main():
     # write final results
     #
     if args.output:
-        with open(os.path.join(args.output, "results.json"), "w") as f:
+        with open("results.json", "w") as f:
             json.dump(final_results, f, sort_keys=True, indent=4)
 
 

--- a/v0.5/classification_and_detection/python/main.py
+++ b/v0.5/classification_and_detection/python/main.py
@@ -12,6 +12,7 @@ import collections
 import json
 import logging
 import os
+import sys
 import threading
 import time
 from queue import Queue
@@ -435,8 +436,13 @@ def main():
         "cmdline": str(args),
     }
 
+    config = os.path.abspath(args.config)
+    if not os.path.exists(config):
+        log.error("{} not found".format(config))
+        sys.exit(1)
+
     if args.output:
-        output_dir = os.path.abspath(os.path.dirname(args.output))
+        output_dir = os.path.abspath(args.output)
         os.makedirs(output_dir, exist_ok=True)
         os.chdir(output_dir)
 
@@ -473,10 +479,7 @@ def main():
             last_timeing = [t / NANO_SEC for t in latencies_ns]
 
         settings = lg.TestSettings()
-        if not os.path.exits(args.config):
-            log.error("{} not found".format(args.config))
-            sys.exit(1)
-        settings.FromConfig(args.config, args.model_name, scenario.name)
+        settings.FromConfig(config, args.model_name, scenario.name)
         settings.scenario = scenario
         settings.mode = lg.TestMode.PerformanceOnly
         if args.accuracy:

--- a/v0.5/classification_and_detection/python/main.py
+++ b/v0.5/classification_and_detection/python/main.py
@@ -61,21 +61,12 @@ SUPPORTED_DATASETS = {
 
 # pre-defined command line options so simplify things. They are used as defaults and can be
 # overwritten from command line
-DEFAULT_LATENCY = "0.100"
-LATENCY_RESNET50 = "0.015"
-LATENCY_MOBILENET = "0.010"
-LATENCY_SSD_MOBILENET = "0.010"
- # FIXME: change once final value is known
-LATENCY_SSD_RESNET34 = "0.100"
 
 SUPPORTED_PROFILES = {
     "defaults": {
         "dataset": "imagenet",
         "backend": "tensorflow",
         "cache": 0,
-        "queries-single": 1024,
-        "queries-multi": 24576,
-        "max-latency": DEFAULT_LATENCY,
         "max-batchsize": 32,
     },
 
@@ -85,13 +76,13 @@ SUPPORTED_PROFILES = {
         "outputs": "ArgMax:0",
         "dataset": "imagenet",
         "backend": "tensorflow",
-        "max-latency": LATENCY_RESNET50,
+        "model-name": "resnet50",
     },
     "resnet50-onnxruntime": {
         "dataset": "imagenet",
         "outputs": "ArgMax:0",
         "backend": "onnxruntime",
-        "max-latency": LATENCY_RESNET50,
+        "model-name": "resnet50",
     },
 
     # mobilenet
@@ -100,13 +91,13 @@ SUPPORTED_PROFILES = {
         "outputs": "MobilenetV1/Predictions/Reshape_1:0",
         "dataset": "imagenet_mobilenet",
         "backend": "tensorflow",
-        "max-latency": LATENCY_MOBILENET,
+        "model-name": "mobilenet",
     },
     "mobilenet-onnxruntime": {
         "dataset": "imagenet_mobilenet",
         "outputs": "MobilenetV1/Predictions/Reshape_1:0",
         "backend": "onnxruntime",
-        "max-latency": LATENCY_MOBILENET,
+        "model-name": "mobilenet",
     },
 
     # ssd-mobilenet
@@ -115,21 +106,21 @@ SUPPORTED_PROFILES = {
         "outputs": "num_detections:0,detection_boxes:0,detection_scores:0,detection_classes:0",
         "dataset": "coco-300",
         "backend": "tensorflow",
-        "max-latency": LATENCY_SSD_MOBILENET,
+        "model-name": "ssd-mobilenet",
     },
     "ssd-mobilenet-pytorch": {
         "inputs": "image",
         "outputs": "bboxes,labels,scores",
         "dataset": "coco-300-pt",
         "backend": "pytorch-native",
-        "max-latency": LATENCY_SSD_MOBILENET,
+        "model-name": "ssd-mobilenet",
     },
     "ssd-mobilenet-onnxruntime": {
         "dataset": "coco-300",
         "outputs": "num_detections:0,detection_boxes:0,detection_scores:0,detection_classes:0",
-        "backend": "onnxruntime",        
+        "backend": "onnxruntime",
         "data-format": "NHWC",
-        "max-latency": LATENCY_SSD_MOBILENET,
+        "model-name": "ssd-mobilenet",
     },
 
     # ssd-resnet34
@@ -139,14 +130,14 @@ SUPPORTED_PROFILES = {
         "dataset": "coco-1200-tf",
         "backend": "tensorflow",
         "data-format": "NCHW",
-        "max-latency": LATENCY_SSD_RESNET34,
+        "model-name": "ssd-resnet34",
     },
     "ssd-resnet34-pytorch": {
         "inputs": "image",
         "outputs": "bboxes,labels,scores",
         "dataset": "coco-1200-pt",
         "backend": "pytorch-native",
-        "max-latency": LATENCY_SSD_RESNET34,
+        "model-name": "ssd-resnet34",
     },
     "ssd-resnet34-onnxruntime": {
         "dataset": "coco-1200-onnx",
@@ -155,7 +146,7 @@ SUPPORTED_PROFILES = {
         "backend": "onnxruntime",
         "data-format": "NCHW",
         "max-batchsize": 1,
-        "max-latency": LATENCY_SSD_RESNET34,
+        "model-name": "ssd-resnet34",
     },
     "ssd-resnet34-onnxruntime-tf": {
         "dataset": "coco-1200-tf",
@@ -163,7 +154,7 @@ SUPPORTED_PROFILES = {
         "outputs": "detection_bboxes:0,detection_classes:0,detection_scores:0",
         "backend": "onnxruntime",
         "data-format": "NHWC",
-        "max-latency": LATENCY_SSD_RESNET34,
+        "model-name": "ssd-resnet34",
     },
 }
 
@@ -187,27 +178,27 @@ def get_args():
     parser.add_argument("--profile", choices=SUPPORTED_PROFILES.keys(), help="standard profiles")
     parser.add_argument("--scenario", default="SingleStream",
                         help="mlperf benchmark scenario, list of " + str(list(SCENARIO_MAP.keys())))
-    parser.add_argument("--queries-single", type=int, default=1024,
-                        help="mlperf number of queries for SingleStream")
-    parser.add_argument("--queries-offline", type=int, default=24576,
-                        help="mlperf number of queries for Offline")
-    parser.add_argument("--queries-multi", type=int, default=24576,
-                        help="mlperf number of queries for MultiStream,Server")
-    parser.add_argument("--max-batchsize", type=int,
-                        help="max batch size in a single inference")
+    parser.add_argument("--max-batchsize", type=int, help="max batch size in a single inference")
     parser.add_argument("--model", required=True, help="model file")
     parser.add_argument("--output", help="test results")
     parser.add_argument("--inputs", help="model inputs")
     parser.add_argument("--outputs", help="model outputs")
     parser.add_argument("--backend", help="runtime to use")
+    parser.add_argument("--model-name", help="name of the mlperf model, ie. resnet50")
     parser.add_argument("--threads", default=os.cpu_count(), type=int, help="threads")
-    parser.add_argument("--time", type=int, help="time to scan in seconds")
-    parser.add_argument("--count", type=int, help="dataset items to use")
-    parser.add_argument("--qps", type=int, default=10, help="target qps estimate")
-    parser.add_argument("--max-latency", type=str, help="mlperf max latency in 99pct tile")
+    parser.add_argument("--qps", type=int, help="target qps")
     parser.add_argument("--cache", type=int, default=0, help="use cache")
     parser.add_argument("--accuracy", action="store_true", help="enable accuracy pass")
     parser.add_argument("--find-peak-performance", action="store_true", help="enable finding peak performance pass")
+
+    # file to use mlperf rules compliant parameters
+    parser.add_argument("--config", default="mlperf.conf", help="mlperf rules config")
+
+    # below will override mlperf rules compliant settings - don't use for official submission
+    parser.add_argument("--time", type=int, help="time to scan in seconds")
+    parser.add_argument("--count", type=int, help="dataset items to use")
+    parser.add_argument("--max-latency", type=float, help="mlperf max latency in pct tile")
+    parser.add_argument("--samples-per-query", type=int, help="mlperf multi-stream sample per query")
     args = parser.parse_args()
 
     # don't use defaults in argparser. Instead we default to a dict, override that with a profile
@@ -225,8 +216,6 @@ def get_args():
         args.inputs = args.inputs.split(",")
     if args.outputs:
         args.outputs = args.outputs.split(",")
-    if args.max_latency:
-        args.max_latency = [float(i) for i in args.max_latency.split(",")]
     try:
         args.scenario = [SCENARIO_MAP[scenario] for scenario in args.scenario.split(",")]
     except:
@@ -423,10 +412,10 @@ def main():
 
     # --count applies to accuracy mode only and can be used to limit the number of images
     # for testing. For perf model we always limit count to 200.
+    count_override = False
     count = args.count
-    if not count:
-        if not args.accuracy:
-            count = 200
+    if count:
+        count_override = True
 
     # dataset to use
     wanted_dataset, pre_proc, post_proc, kwargs = SUPPORTED_DATASETS[args.dataset]
@@ -445,6 +434,11 @@ def main():
         "time": int(time.time()),
         "cmdline": str(args),
     }
+
+    if args.output:
+        output_dir = os.path.abspath(os.path.dirname(args.output))
+        os.makedirs(output_dir, exist_ok=True)
+        os.chdir(output_dir)
 
     #
     # make one pass over the dataset to validate accuracy
@@ -470,7 +464,8 @@ def main():
         def issue_queries(query_samples):
             runner.enqueue(query_samples)
 
-        def flush_queries(): pass
+        def flush_queries():
+            pass
 
         def process_latencies(latencies_ns):
             # called by loadgen to show us the recorded latencies
@@ -478,6 +473,10 @@ def main():
             last_timeing = [t / NANO_SEC for t in latencies_ns]
 
         settings = lg.TestSettings()
+        if not os.path.exits(args.config):
+            log.error("{} not found".format(args.config))
+            sys.exit(1)
+        settings.FromConfig(args.config, args.model_name, scenario.name)
         settings.scenario = scenario
         settings.mode = lg.TestMode.PerformanceOnly
         if args.accuracy:
@@ -495,49 +494,29 @@ def main():
             settings.server_target_qps = qps
             settings.offline_expected_qps = qps
 
-        if scenario == lg.TestScenario.SingleStream:
-            settings.min_query_count = args.queries_single
-            settings.max_query_count = args.queries_single
-        elif scenario == lg.TestScenario.MultiStream:
-            settings.min_query_count = args.queries_multi
-            settings.max_query_count = args.queries_multi
-            settings.multi_stream_samples_per_query = 4
-        elif scenario == lg.TestScenario.Server:
-            max_latency = args.max_latency
-        elif scenario == lg.TestScenario.Offline:
-            settings.min_query_count = args.queries_offline
-            settings.max_query_count = args.queries_offline
+        if count_override:
+            settings.min_query_count = count
+            settings.max_query_count = count
+
+        if args.samples_per_query:
+            settings.multi_stream_samples_per_query = args.samples_per_query
+        if args.max_latency:
+            settings.server_target_latency_ns = int(args.max_latency * NANO_SEC)
 
         sut = lg.ConstructSUT(issue_queries, flush_queries, process_latencies)
-        qsl = lg.ConstructQSL(count, min(count, 1000), ds.load_query_samples, ds.unload_query_samples)
+        qsl = lg.ConstructQSL(count, min(count, 500), ds.load_query_samples, ds.unload_query_samples)
 
-        if scenario == lg.TestScenario.Server:
-            for target_latency in max_latency:
-                log.info("starting {}, latency={}".format(scenario, target_latency))
-                settings.server_target_latency_ns = int(target_latency * NANO_SEC)
+        log.info("starting {}".format(scenario))
+        result_dict = {"good": 0, "total": 0, "scenario": str(scenario)}
+        runner.start_run(result_dict, args.accuracy)
+        lg.StartTest(sut, qsl, settings)
 
-                result_dict = {"good": 0, "total": 0, "scenario": str(scenario)}
-                runner.start_run(result_dict, args.accuracy)
-                lg.StartTest(sut, qsl, settings)
-
-                if not last_timeing:
-                    last_timeing = runner.result_timing
-                if args.accuracy:
-                    post_proc.finalize(result_dict, ds, output_dir=os.path.dirname(args.output))
-                add_results(final_results, "{}-{}".format(scenario, target_latency),
-                            result_dict, last_timeing, time.time() - ds.last_loaded, args.accuracy)
-        else:
-            log.info("starting {}".format(scenario))
-            result_dict = {"good": 0, "total": 0, "scenario": str(scenario)}
-            runner.start_run(result_dict, args.accuracy)
-            lg.StartTest(sut, qsl, settings)
-
-            if not last_timeing:
-                last_timeing = runner.result_timing
-            if args.accuracy:
-                post_proc.finalize(result_dict, ds, output_dir=os.path.dirname(args.output))
-            add_results(final_results, "{}".format(scenario),
-                        result_dict, last_timeing, time.time() - ds.last_loaded, args.accuracy)
+        if not last_timeing:
+            last_timeing = runner.result_timing
+        if args.accuracy:
+            post_proc.finalize(result_dict, ds, output_dir=os.path.dirname(args.output))
+        add_results(final_results, "{}".format(scenario),
+                    result_dict, last_timeing, time.time() - ds.last_loaded, args.accuracy)
 
         runner.finish()
         lg.DestroyQSL(qsl)
@@ -549,7 +528,6 @@ def main():
     if args.output:
         with open(args.output, "w") as f:
             json.dump(final_results, f, sort_keys=True, indent=4)
-
 
 
 if __name__ == "__main__":

--- a/v0.5/classification_and_detection/python/main.py
+++ b/v0.5/classification_and_detection/python/main.py
@@ -529,7 +529,7 @@ def main():
     # write final results
     #
     if args.output:
-        with open(args.output, "w") as f:
+        with open(os.path.join(args.output, "results.json"), "w") as f:
             json.dump(final_results, f, sort_keys=True, indent=4)
 
 

--- a/v0.5/classification_and_detection/python/main.py
+++ b/v0.5/classification_and_detection/python/main.py
@@ -193,7 +193,7 @@ def get_args():
     parser.add_argument("--find-peak-performance", action="store_true", help="enable finding peak performance pass")
 
     # file to use mlperf rules compliant parameters
-    parser.add_argument("--config", default="mlperf.conf", help="mlperf rules config")
+    parser.add_argument("--config", default="../mlperf.conf", help="mlperf rules config")
 
     # below will override mlperf rules compliant settings - don't use for official submission
     parser.add_argument("--time", type=int, help="time to scan in seconds")

--- a/v0.5/classification_and_detection/run_and_time.sh
+++ b/v0.5/classification_and_detection/run_and_time.sh
@@ -7,6 +7,8 @@ if [ $device == "gpu" ]; then
     runtime="--runtime=nvidia"
 fi
 
+# copy the config to cwd so the docker contrainer has access
+cp ../mlperf.conf .
 
 OUTPUT_DIR=`pwd`/output/$name
 mkdir -p $OUTPUT_DIR
@@ -14,7 +16,7 @@ mkdir -p $OUTPUT_DIR
 image=mlperf-infer-imgclassify-$device
 docker build  -t $image -f Dockerfile.$device .
 opts="--profile $profile $common_opt --model $model_path --dataset-path $DATA_DIR \
-    --output $OUTPUT_DIR/results.json $extra_args $EXTRA_OPS"
+    --output $OUTPUT_DIR $extra_args $EXTRA_OPS"
 
 docker run $runtime -e opts="$opts" \
     -v $DATA_DIR:$DATA_DIR -v $MODEL_DIR:$MODEL_DIR -v `pwd`:/mlperf \

--- a/v0.5/classification_and_detection/run_local.sh
+++ b/v0.5/classification_and_detection/run_local.sh
@@ -2,8 +2,7 @@
 
 source ./run_common.sh
 
-
-common_opt=""
+common_opt="--config ../mlperf.conf"
 dataset="--dataset-path $DATA_DIR"
 OUTPUT_DIR=`pwd`/output/$name
 if [ ! -d $OUTPUT_DIR ]; then
@@ -11,4 +10,4 @@ if [ ! -d $OUTPUT_DIR ]; then
 fi
 
 python python/main.py --profile $profile $common_opt --model $model_path $dataset \
-    --output $OUTPUT_DIR/results.json $EXTRA_OPS $@
+    --output $OUTPUT_DIR $EXTRA_OPS $@

--- a/v0.5/mlperf.conf
+++ b/v0.5/mlperf.conf
@@ -8,7 +8,7 @@
 *.SingleStream.min_duration = 60000
 *.SingleStream.min_query_count = 1024
 
-*.MultiStream.target_qps = 1
+*.MultiStream.target_qps = 1.0
 *.MultiStream.target_latency_percentile = 90
 *.MultiStream.samples_per_query = 4
 *.MultiStream.max_async_queries = 1
@@ -19,7 +19,7 @@ gnmt.MultiStream.min_query_count = 90112
 mobilenet.MultiStream.target_latency = 66
 gnmt.MultiStream.target_latency = 100
 
-*.Server.target_qps = 1
+*.Server.target_qps = 1.0
 *.Server.target_latency = 10
 *.Server.target_latency_percentile = 99
 *.Server.target_duration = 0
@@ -31,7 +31,7 @@ ssd-mobilenet.Server.target_latency = 10
 resnet50.Server.target_latency = 15
 gnmt.Server.target_latency = 250
 
-*.Offline.target_qps = 1
+*.Offline.target_qps = 1.0
 *.Offline.target_latency_percentile = 90
 *.Offline.min_duration = 60000
 *.Offline.min_query_count = 1

--- a/v0.5/mlperf.conf
+++ b/v0.5/mlperf.conf
@@ -1,0 +1,37 @@
+# The format of this config file is 'key = value'.
+# The key has the format 'model.scenario.key'. Value is mostly int64_t.
+# Model maybe '*' as wildcard. In that case the value applies to all models.
+# All times are in milli seconds
+
+*.SingleStream.target_latency = 0
+*.SingleStream.target_latency_percentile = 90
+*.SingleStream.min_duration = 60000
+*.SingleStream.min_query_count = 1024
+
+*.MultiStream.target_qps = 1
+*.MultiStream.target_latency_percentile = 90
+*.MultiStream.samples_per_query = 4
+*.MultiStream.max_async_queries = 1
+*.MultiStream.target_latency = 50
+*.MultiStream.min_duration = 60000
+*.MultiStream.min_query_count = 270336
+gnmt.MultiStream.min_query_count = 90112
+mobilenet.MultiStream.target_latency = 66
+gnmt.MultiStream.target_latency = 100
+
+*.Server.target_qps = 1
+*.Server.target_latency = 10
+*.Server.target_latency_percentile = 99
+*.Server.target_duration = 0
+*.Server.min_duration = 60000
+*.Server.min_query_count = 270336
+gnmt.Server.min_query_count = 90112
+mobilenet.Server.target_latency = 10
+ssd-mobilenet.Server.target_latency = 10
+resnet50.Server.target_latency = 15
+gnmt.Server.target_latency = 250
+
+*.Offline.target_qps = 1
+*.Offline.target_latency_percentile = 90
+*.Offline.min_duration = 60000
+*.Offline.min_query_count = 1

--- a/v0.5/mlperf.conf
+++ b/v0.5/mlperf.conf
@@ -3,7 +3,7 @@
 # Model maybe '*' as wildcard. In that case the value applies to all models.
 # All times are in milli seconds
 
-*.SingleStream.target_latency = 0
+*.SingleStream.target_latency = 10
 *.SingleStream.target_latency_percentile = 90
 *.SingleStream.min_duration = 60000
 *.SingleStream.min_query_count = 1024


### PR DESCRIPTION
cut at moving model / scenario / rules specific parameters into a config file.
The file format is a simple key/value format instead of json to avoid dependencies to additional components.
This change should not break anything that works today, it just initializes the settings from the config file but if an app sets it the old way it still works.

Things I have not been sure about:
error handling - did not want to start making loadgen throw exceptions. Because of this the error text is not returned and instead we use error codes.
There are some error messages emitted by the code (like which line number in the config file is bad) but at that time logging in the loadgen is not initialize yet and no errors pop up.
