### PR TITLE
[GNMT] + Contiguous samples in accuracy mode

### DIFF
--- a/loadgen/loadgen.cc
+++ b/loadgen/loadgen.cc
@@ -356,8 +356,7 @@ std::vector<QueryMetadata> GenerateQueries(
         // query as the value of samples_per_query increases.
         s = loaded_samples[sample_i++];
       }
-    } else if (mode == TestMode::PerformanceOnly &&
-               scenario == TestScenario::Offline) {
+    } else if (scenario == TestScenario::Offline) {
       // For the Offline + Performance scenario, we also want to support
       // contiguous samples. In this scenario the query can be much larger than
       // what fits into memory. We simply repeat loaded_samples N times, plus a


### PR DESCRIPTION
@briandersn , when testing (on GNMT) I noticed that Offline + Accuracy mode is generating a lot of queries. Shouldn't it just generate one single query? It's ignoring my settings on https://github.com/mlperf/inference/blob/master/v0.5/translation/gnmt/tensorflow/loadgen_gnmt.py#L476

Samples inside a query are contiguous though.