### PR TITLE
fix reference app

### DIFF
--- a/v0.5/classification_and_detection/python/coco.py
+++ b/v0.5/classification_and_detection/python/coco.py
@@ -219,9 +219,7 @@ class PostProcessCoco:
                            "bbox": [float(detection[1]), float(detection[2]),
                                     float(detection[3]), float(detection[4])],
                            "score": float(detection[5])})
-            if not output_dir:
-                output_dir = "/tmp"
-            fname = "{}/{}.json".format(output_dir, result_dict["scenario"])
+            fname = "{}.json".format(result_dict["scenario"])
             with open(fname, "w") as fp:
                 json.dump(pp, fp, sort_keys=True, indent=4)
 


### PR DESCRIPTION
previous checkin for loadgen conf change the args.output to be a directory and set cwd to that directory so no need to prefix the filename with  args.output