### PR TITLE
loadgen: Pre-allocate logging entries.

### DIFF
--- a/loadgen/loadgen.cc
+++ b/loadgen/loadgen.cc
@@ -702,7 +702,7 @@ PerformanceResult IssueQueries(SystemUnderTest* sut,
       GlobalLogger().GetLatenciesBlocking(expected_latencies));
 
   // Log contention counters after every test as a sanity check.
-  GlobalLogger().LogContentionCounters();
+  GlobalLogger().LogContentionAndAllocations();
 
   double max_latency =
       QuerySampleLatencyToSeconds(GlobalLogger().GetMaxLatencySoFar());
@@ -744,12 +744,10 @@ struct PerformanceSummary {
   PercentileEntry latency_percentiles[6] = {{.50}, {.90}, {.95},
                                             {.97}, {.99}, {.999}};
 
-  PerformanceSummary(
-      const std::string& sut_name_arg,
-      const TestSettingsInternal& settings_arg,
-      const PerformanceResult& pr_arg)
-      : sut_name(sut_name_arg), settings(settings_arg), pr(pr_arg) {
-  };
+  PerformanceSummary(const std::string& sut_name_arg,
+                     const TestSettingsInternal& settings_arg,
+                     const PerformanceResult& pr_arg)
+      : sut_name(sut_name_arg), settings(settings_arg), pr(pr_arg){};
 
   void ProcessLatencies();
 

--- a/loadgen/logging.cc
+++ b/loadgen/logging.cc
@@ -62,6 +62,10 @@ bool SwapRequestSlotIsReadable(uintptr_t value) {
 constexpr size_t kMaxThreadsToLog = 1024;
 constexpr std::chrono::milliseconds kLogPollPeriod(10);
 
+/// \brief How many log entries to pre-allocate per thread to help avoid
+/// runtime allocation.
+constexpr size_t kTlsLogReservedEntryCount = 1024;
+
 constexpr auto kInvalidLatency = std::numeric_limits<QuerySampleLatency>::min();
 
 }  // namespace
@@ -103,6 +107,16 @@ void AsyncLog::SetLogFiles(std::ostream* summary, std::ostream* detail,
                            PerfClock::time_point log_origin) {
   std::unique_lock<std::mutex> lock(log_mutex_);
   if (summary_out_ != &std::cerr) {
+    std::string warning_summary;
+    if (log_warning_count_ == 0) {
+      warning_summary = "\nNo warnings encountered during test.\n";
+    } else if (log_warning_count_ == 1) {
+      warning_summary = "\n1 warning encountered. See detailed log.\n";
+    } else if (log_warning_count_ != 0) {
+      warning_summary = "\n" + std::to_string(log_warning_count_) +
+                        " warnings encountered. See detailed log.\n";
+    }
+
     std::string error_summary;
     if (log_error_count_ == 0) {
       error_summary = "\nNo errors encountered during test.\n";
@@ -112,9 +126,10 @@ void AsyncLog::SetLogFiles(std::ostream* summary, std::ostream* detail,
       error_summary = "\n" + std::to_string(log_error_count_) +
                       " ERRORS encountered. See detailed log.\n";
     }
-    *summary_out_ << error_summary;
+
+    *summary_out_ << warning_summary << error_summary;
     if (copy_summary_to_stdout_) {
-      std::cout << error_summary;
+      std::cout << warning_summary << error_summary;
     }
   }
   if (summary_out_) {
@@ -137,6 +152,7 @@ void AsyncLog::SetLogFiles(std::ostream* summary, std::ostream* detail,
   copy_summary_to_stdout_ = copy_summary_to_stdout;
   log_origin_ = log_origin;
   log_error_count_ = 0;
+  log_warning_count_ = 0;
 }
 
 void AsyncLog::StartNewTrace(std::ostream* trace_out,
@@ -329,6 +345,7 @@ class TlsLogger {
   std::vector<AsyncLogEntry>* StartReadingEntries();
   void FinishReadingEntries();
   bool ReadBufferHasBeenConsumed();
+  size_t MaxEntryVectorSize() { return max_entry_size_; }
 
   const std::string* TracePidTidString() const { return &trace_pid_tid_; }
 
@@ -373,6 +390,7 @@ class TlsLogger {
   size_t i_write_prev_ = 0;
   std::string trace_pid_tid_;  // Cached as string.
   std::string tid_as_string_;  // Cached as string.
+  size_t max_entry_size_ = kTlsLogReservedEntryCount;
 
   std::function<void()> forced_detatch_;
 };
@@ -471,6 +489,15 @@ void Logger::CollectTlsLoggerStats(TlsLogger* tls_logger) {
   tls_total_log_cas_fail_count_ += tls_logger->ReportLogCasFailCount();
   tls_total_swap_buffers_slot_retry_count_ +=
       tls_logger->ReportSwapBuffersSlotRetryCount();
+
+  size_t max_entry_vector_size = tls_logger->MaxEntryVectorSize();
+  if (max_entry_vector_size > kTlsLogReservedEntryCount) {
+    async_logger_.FlagWarning();
+    async_logger_.LogDetail("Logging allocation detected: ", "tid",
+                            tls_logger->TidAsString(), "reserved_entries",
+                            kTlsLogReservedEntryCount, "max_entries",
+                            max_entry_vector_size);
+  }
 }
 
 void Logger::StartIOThread() {
@@ -524,7 +551,7 @@ void Logger::StopTracing() {
   async_logger_.StartNewTrace(nullptr, PerfClock::now());
 }
 
-void Logger::LogContentionCounters() {
+void Logger::LogContentionAndAllocations() {
   LogDetail([&](AsyncDetail& detail) {
     {
       std::unique_lock<std::mutex> lock(tls_loggers_registerd_mutex_);
@@ -702,6 +729,11 @@ void Logger::IOThread() {
       RemoveValue(&threads_to_read_, nullptr);
     }
 
+    // Explicitly flush every time we wake up. The goal being minimization
+    // of large implicit flushes which could affect tail latency measurements,
+    // especially at percentiles closer to 100%.
+    /// \todo Determine if explicitly flushing logs every wake up is better
+    /// than relying on implicit flushing.
     {
       auto tracer6 =
           MakeScopedTracer([](AsyncTrace& trace) { trace("FlushAll"); });
@@ -727,6 +759,9 @@ TlsLogger::TlsLogger(std::function<void()> forced_detatch)
   tid_as_string_ = ss.str();
   trace_pid_tid_ = "\"pid\": " + std::to_string(MLPERF_GET_PID()) + ", " +
                    "\"tid\": " + tid_as_string_ + ", ";
+  for (auto& entry : entries_) {
+    entry.reserve(kTlsLogReservedEntryCount);
+  }
 }
 
 TlsLogger::~TlsLogger() {}
@@ -801,6 +836,17 @@ std::vector<AsyncLogEntry>* TlsLogger::StartReadingEntries() {
 }
 
 void TlsLogger::FinishReadingEntries() {
+  // Detect first logging allocation and track max allocated size.
+  size_t new_size = entries_[i_read_].size();
+  if (new_size > max_entry_size_) {
+    if (max_entry_size_ == kTlsLogReservedEntryCount) {
+      Log([ts = PerfClock::now()](AsyncLog& log) {
+        log.TraceAsyncInstant("FirstAllocation", 0, ts);
+      });
+    }
+    max_entry_size_ = new_size;
+  }
+
   entries_[i_read_].clear();
   unread_swaps_--;
 }

--- a/loadgen/test_settings.h
+++ b/loadgen/test_settings.h
@@ -234,7 +234,7 @@ struct TestSettings {
 
   /// \brief Load mlperf parameter config from file.
   int FromConfig(const std::string &config_file, const std::string &model,
-                 const std::string &mode);
+                 const std::string &scenario);
   /**@}*/
 };
 

--- a/loadgen/test_settings_internal.cc
+++ b/loadgen/test_settings_internal.cc
@@ -10,13 +10,14 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
+#include "test_settings_internal.h"
+
 #include <fstream>
 #include <map>
 #include <sstream>
 #include <string>
 
 #include "logging.h"
-#include "test_settings_internal.h"
 #include "utils.h"
 
 namespace mlperf {
@@ -63,10 +64,8 @@ TestSettingsInternal::TestSettingsInternal(
       if (requested.server_target_qps >= 0.0) {
         target_qps = requested.server_target_qps;
       } else {
-        LogDetail([
-          server_target_qps = requested.server_target_qps,
-          target_qps = target_qps
-        ](AsyncDetail & detail) {
+        LogDetail([server_target_qps = requested.server_target_qps,
+                   target_qps = target_qps](AsyncDetail &detail) {
           detail.Error("Invalid value for server_target_qps requested.",
                        "requested", server_target_qps, "using", target_qps);
         });
@@ -81,10 +80,8 @@ TestSettingsInternal::TestSettingsInternal(
       if (requested.offline_expected_qps >= 0.0) {
         target_qps = requested.offline_expected_qps;
       } else {
-        LogDetail([
-          offline_expected_qps = requested.offline_expected_qps,
-          target_qps = target_qps
-        ](AsyncDetail & detail) {
+        LogDetail([offline_expected_qps = requested.offline_expected_qps,
+                   target_qps = target_qps](AsyncDetail &detail) {
           detail.Error("Invalid value for offline_expected_qps requested.",
                        "requested", offline_expected_qps, "using", target_qps);
         });
@@ -204,7 +201,7 @@ void LogRequestedTestSettings(const TestSettings &s) {
 }
 
 void TestSettingsInternal::LogEffectiveSettings() const {
-  LogDetail([s = *this](AsyncDetail & detail) {
+  LogDetail([s = *this](AsyncDetail &detail) {
     detail("");
     detail("Effective Settings:");
 
@@ -253,6 +250,9 @@ void TestSettingsInternal::LogSummary(AsyncSummary &summary) const {
 
 }  // namespace loadgen
 
+/// \todo The TestSettings::FromConfig definition belongs in a test_settings.cc
+/// file which doesn't yet exist. To avoid churn so close to the submission
+/// deadline, adding a test_settings.cc file has been deferred to v0.6.
 int TestSettings::FromConfig(const std::string &path, const std::string &model,
                              const std::string &scenario) {
   // TODO: move this method to a new file test_settings.cc
@@ -289,7 +289,7 @@ int TestSettings::FromConfig(const std::string &path, const std::string &model,
   int line_nr = 0;
   int errors = 0;
   if (!fss.is_open()) {
-    LogDetail([p = path](AsyncDetail & detail) {
+    LogDetail([p = path](AsyncDetail &detail) {
       detail.Error("can't open file ", p);
     });
     return -ENOENT;
@@ -298,7 +298,7 @@ int TestSettings::FromConfig(const std::string &path, const std::string &model,
     line_nr++;
     std::istringstream iss(line);
     std::string s, k;
-    int looking_for = 0; // 0=key, 1=equal, 2=value
+    int looking_for = 0;  // 0=key, 1=equal, 2=value
     while (iss >> s) {
       if (s == "#" && looking_for != 2) {
         // done with this line
@@ -319,14 +319,14 @@ int TestSettings::FromConfig(const std::string &path, const std::string &model,
           continue;
         }
         errors++;
-        LogDetail([l = line_nr](AsyncDetail & detail) {
+        LogDetail([l = line_nr](AsyncDetail &detail) {
           detail.Error("value needs to be integer or double, line=", l);
         });
         break;
       }
       if (looking_for == 1 && s != "=") {
         errors++;
-        LogDetail([l = line_nr](AsyncDetail & detail) {
+        LogDetail([l = line_nr](AsyncDetail &detail) {
           detail.Error("expected 'key=value', line=", l);
         });
         break;
@@ -374,6 +374,6 @@ int TestSettings::FromConfig(const std::string &path, const std::string &model,
   lookupkv(model, "Offline", "target_qps", 0, &offline_expected_qps);
 
   return 0;
-};
+}
 
 }  // namespace mlperf

--- a/loadgen/test_settings_internal.h
+++ b/loadgen/test_settings_internal.h
@@ -79,7 +79,7 @@ struct TestSettingsInternal {
 /// mainly about binary search.
 namespace find_peak_performance {
 
-constexpr char const* kNotSupportedMsg =
+constexpr char const *kNotSupportedMsg =
     "Finding peak performance is only supported in MultiStream, "
     "MultiStreamFree, and Server scenarios.";
 
@@ -102,8 +102,7 @@ TestSettingsInternal MidOfBoundaries(
         lower_bound_settings.target_qps +
         (upper_bound_settings.target_qps - lower_bound_settings.target_qps) / 2;
   } else {
-    LogDetail(
-        [](AsyncDetail &detail) { detail(kNotSupportedMsg); });
+    LogDetail([](AsyncDetail &detail) { detail(kNotSupportedMsg); });
   }
   return mid_settings;
 }
@@ -124,8 +123,7 @@ bool IsFinished(const TestSettingsInternal &lower_bound_settings,
         std::floor(upper_bound_settings.target_qps * std::pow(10, precision));
     return l + 1 >= u;
   } else {
-    LogDetail(
-        [](AsyncDetail &detail) { detail(kNotSupportedMsg); });
+    LogDetail([](AsyncDetail &detail) { detail(kNotSupportedMsg); });
     return true;
   }
 }
@@ -138,8 +136,7 @@ std::string ToStringPerformanceField(const TestSettingsInternal &settings) {
   } else if (scenario == TestScenario::Server) {
     return std::to_string(settings.target_qps);
   } else {
-    LogDetail(
-        [](AsyncDetail &detail) { detail(kNotSupportedMsg); });
+    LogDetail([](AsyncDetail &detail) { detail(kNotSupportedMsg); });
     return ToString(settings.scenario);
   }
 }
@@ -154,8 +151,7 @@ void WidenPerformanceField(TestSettingsInternal *settings) {
         settings->target_qps *
         (1 + settings->requested.server_find_peak_qps_boundary_step_size);
   } else {
-    LogDetail(
-        [](AsyncDetail &detail) { detail(kNotSupportedMsg); });
+    LogDetail([](AsyncDetail &detail) { detail(kNotSupportedMsg); });
   }
 }
 


### PR DESCRIPTION
* Pre-allocates 1024 logging entries per thread.
* Adds warning mechanism to Logger.
* Prints warning if a thread exceeds the pre-allocated
  entries.
* Clang-format and small clean ups.