### PR TITLE
Fix issues in accuracy checking script

### DIFF
--- a/v0.5/classification_and_detection/tools/accuracy-coco.py
+++ b/v0.5/classification_and_detection/tools/accuracy-coco.py
@@ -25,6 +25,8 @@ def get_args():
     parser.add_argument("--mlperf-accuracy-file", required=True, help="path to mlperf_log_accuracy.json")
     parser.add_argument("--coco-dir", required=True, help="coco directory")
     parser.add_argument("--verbose", action="store_true", help="verbose messages")
+    parser.add_argument("--output-file", default="coco-results.json", help="path to output file")
+    parser.add_argument("--use-inv-map", action="store_true", help="use inverse label map")
     args = parser.parse_args()
     return args
 
@@ -33,6 +35,9 @@ def main():
     args = get_args()
 
     cocoGt = COCO(os.path.join(args.coco_dir, "annotations/instances_val2017.json"))
+
+    if args.use_inv_map:
+        inv_map = [0] + cocoGt.getCatIds() # First label in inv_map is not used
 
     with open(args.mlperf_accuracy_file, "r") as f:
         results = json.load(f)
@@ -56,8 +61,7 @@ def main():
         data = np.frombuffer(bytes.fromhex(j['data']), np.float32)
         for i in range(0, len(data), 7):
             image_idx, ymin, xmin, ymax, xmax, score, label = data[i:i + 7]
-            image_idx = int(image_idx)
-            image = image_map[image_idx]
+            image = image_map[idx]
             image_id = image["id"]
             height, width = image["height"], image["width"]
             ymin *= height
@@ -65,19 +69,22 @@ def main():
             ymax *= height
             xmax *= width
             loc = os.path.join(args.coco_dir, "val2017", image["file_name"])
+            label = int(label)
+            if args.use_inv_map:
+                label = inv_map[label]
             # pycoco wants {imageID,x1,y1,w,h,score,class}
             detections.append({
                 "image_id": image_id,
                 "image_loc": loc,
-                "category_id": int(label),
+                "category_id": label,
                 "bbox": [float(xmin), float(ymin), float(xmax - xmin), float(ymax - ymin)],
                 "score": float(score)})
             image_ids.add(image_id)
 
-    with open("coco-results.json", "w") as fp:
+    with open(args.output_file, "w") as fp:
         json.dump(detections, fp, sort_keys=True, indent=4)
 
-    cocoDt = cocoGt.loadRes(detections)
+    cocoDt = cocoGt.loadRes(args.output_file) # Load from file to bypass error with Python3
     cocoEval = COCOeval(cocoGt, cocoDt, iouType='bbox')
     cocoEval.params.imgIds = list(image_ids)
     cocoEval.evaluate()

--- a/v0.5/classification_and_detection/tools/accuracy-imagenet.py
+++ b/v0.5/classification_and_detection/tools/accuracy-imagenet.py
@@ -21,9 +21,15 @@ def get_args():
     parser.add_argument("--mlperf-accuracy-file", required=True, help="path to mlperf_log_accuracy.json")
     parser.add_argument("--imagenet-val-file", required=True, help="path to imagenet val_map.txt")
     parser.add_argument("--verbose", action="store_true", help="verbose messages")
+    parser.add_argument("--dtype", default="float32", choices=["float32", "int32", "int64"], help="data type of the label")
     args = parser.parse_args()
     return args
 
+dtype_map = {
+    "float32": np.float32,
+    "int32": np.int32,
+    "int64": np.int64
+}
 
 def main():
     args = get_args()
@@ -51,7 +57,7 @@ def main():
         img, label = imagenet[idx]
 
         # reconstruct label from mlperf accuracy log
-        data = np.frombuffer(bytes.fromhex(j['data']), np.float32)
+        data = np.frombuffer(bytes.fromhex(j['data']), dtype_map[args.dtype])
         found = int(data[0])
         if label == found:
             good += 1


### PR DESCRIPTION
Default behavior is not changed.

Changes made in `accuracy-imagenet.py`:
- Add `--dtype` option to specify the data type of the predicted label
  - Reference model saves the predicted label in FP32, but label is in fact an integer and some SUTs might saves it as INT32 or INT64 directly.

Changes made in `accuracy-coco.py`:
- Add `--output-file` option to specify where the user wants to save the resulting JSON file.
  - In some systems, $PWD might not be writable.
- Pass in JSON file name instead of object itself to `cocoGt.loadRes()` to bypass an error when running the script with Python3.
- Add `--use-inv-map` option to enable label mapping
  - As mentioned in #389, this step is done in the finalize() step in the reference model and is not timed. Therefore, the accuracy script should allow the user to do this step here.
- Use `qsl_idx` for image index
  - As mentioned in #390, `qsl_idx` is an information available in LoadGen logs. `accuracy-imagenet.py` also uses `qsl_idx` for image index.

Please feel free to let me know if there is anything that needs to be fixed. Thanks!