### PR TITLE
[GNMT] Added English calibration data

### DIFF
--- a/calibration/translation/calibration_data.en
+++ b/calibration/translation/calibration_data.en
@@ -1,0 +1,500 @@
+His efforts were unsuccessful, but did inspire locals to begin planning a tongue-in-cheek Ben Cousins biathlon.
+His third album, "Greetings from Michigan: the Great Lake State", released in 2003, features cleverly composed songs which cling harmonically to the traditions of American folk rock of the late sixties, but which might drift at any time into amazing opulence.
+She also wants to use the EU environment better, and get more Czechs into European institutions.
+or with a white ice cream base that can be turned into yellow cream by using eggs or can be mixed with cocoa powder to form the base of all kinds of seductive chocolate.
+In the letter, Germans from Český Krumlov request that the American president not to allow the return of the "Šumava region" - occupied by Hitler on the basis of the Munich Agreement - to Czechoslovakia.
+"He is a person who can listen to all twenty-seven member states, communicate with them perfectly, and who has a clear vision of where the EU should be headed."
+The group complained that the sums quoted in the broadcasts were not accurate.
+Cuba: hundreds of Government supporters speak out against the "Ladies in White"
+Nine years later, the 30-million-euro mountain has been lifted up.
+Zelaya's departure attempt from Honduras to Mexico aborted
+Also, I think you can be a happy person and still be able to make music that is dark.
+Czech army has purchased 445 kilometers of cords, which detonate explosives.
+On how to spend the rest of the 700 billion dollars will be decided by the Congress.
+Taking into account the large exposure of European banks to sovereign debt markets of the Euro zone, the issuing institute has no option other than to maintain a presence in the market.
+In the major cities there are multi-level department stores that sell counterfeit goods almost exclusively.
+"The number of such institutes will be growing; it will be a highly two-speed Europe," Vicenová expects.
+The trail of the Stuttgart stones leads to a forest in Tübingen and a former French munitions depot where Manuel Rongen has created his own world of stone.
+I just know what those people feel, the horror of it.
+More flavourings, more fruit purée - not necessarily an improvement in taste.
+It will be done "in a very short time", assures Mr. Bussereau.
+"Sixty-six parent coordinators were laid off," the draft complaint says, "and not merely excessed."
+This emerges from a long-term study by an international team of researchers, including a number of employees of the German Institute for Nutritional Research (DIfE) in Potsdam.
+Potentially, a large number of cameras could solve the problem...
+Astonomers concluded at the time that there had to be a subsurface sea at least at the south pole.
+The tot was crying so hard that she vomited, she added.
+At a press conference, Colom said that his decision is according to the independence of judiciary and executive powers, taking into account that a trial court had already ordered the extradition.
+However, they managed and retained the profit, even though lower than before the crisis.
+A Mississippi newspaper, deep in the South of the United States, wrote an editorial: once inside the voting cabin we know well enough to whom the American patriot will give his vote.
+With the duel of Santos Laguna and Monterrey in the final, in addition two different styles marked by their technicians' face, who find each other with a contrast marked by results.
+However, Berlin subsequently abstained from voting.
+At the end of last April, the municipal council of Gioia Tauro was dissolved but already in 1991, and always for presumed conditioning between organised crime and local administration, local politicians had been relieved from duties of administration of the municipality.
+I should be careful with my knee which was injured but I walk fine now.
+Superglue to be able to walk on walls
+At the moment, Paclík's strongest disagreement with Pelta is based on the latter's connection to Roman Berbr, President of Pilsen's regional football association. Berber is a man of controversial reputation, who is, behind the scenes, known as powerful lobbyist, capable of influencing the votes of general meeting delegates.
+I think that in Europe, and even in the USA, a great understanding for the German position prevails.
+The victims were mainly elderly women tending the plots of relatives.
+A 29-year-old wanted to fulfil a dream and rented a Ford Mustang.
+Cornerback Darrelle Revis intercepted an errant throw and returned it 32 yards for a touchdown.
+I'm a patriotic husband, you're my patriotic wife, let's do our civic duty and create life!
+"This thing is evolving so quickly that I don't know what's going to happen next," said Daniel J. Oates, the police chief in Aurora, just east of Denver.
+Or does Germany still find leadership roles difficult?
+A combination of genres
+After all, the balance sheet total for UBS in 2007 was more than five times the economic output of Switzerland (see chart).
+The people who have travelled there will then be housed in emergency shelters in Wiesbaden, according to a statement made by the city of Wiesbaden on Tuesday evening.
+This is the photograph's aim when collecting an original iconography of flamenco, taken from different perspectives.
+Although this does not guarantee that it was the murderer, it places him it in the murder scene.
+At the main Pennsylvania State University campus, Latin American History Professor Matthew Restall, and his colleague Amara Solari, an Associate Art History and Anthropology Professor, have teamed up to give a course, called simply "The end of the world."
+But the greatest advantage of the music cell phones for many people is the price.
+"He has never had any interest in Kallstadt."
+Petronella Wyatt: I was bullied out of Oxford for being a Tory
+"For the first time it was said that the countries who want are to cooperate, while those who are not willing can stand off."
+The female employee suffered from shock.
+Now that we are 7 thousand million human beings on the planet, demographic development will involve a doubling of demand for electricity by 2050, unless a huge proportion of the world's population is deprived of a vital element.
+"At first you think of working for posterity, then you realize you only work for the prosperity, and at certain point you just shoot a film more," says Garcia after more 30 years of career.
+The decision was taken unanimously by the 11 judges, while a majority of seven was sufficient to force the disbanding, Mr. Kiliç indicated, adding that 37 of the party's representatives, including its president, Ahmet Türk, and the deputy, Aysel Tugluk, have been banished from political life for the next five years.
+"I think that applicants are influenced strongly by external assessments of any potential employer," she says.
+Playing live he only needs a guitar and banjo.
+Paraguay, which was suspended by UNASUR in 2011 after the dismissal of former President Fernando Lugo, was not involved in the meeting.
+The nebula, 1,400 light years away, consists of particles of dust that are ten to one hundred times smaller than standard house dust.
+They recognised the size and shape of stone needed to collapse the platform without much training.
+The police announced in a statement that tenants of the building on Marienfelder Allee noticed smoke on the staircase and contacted the fire brigade.
+`Run!' Run and man the seats in the rear part of the tent.
+For part of Depfa's loan portfolio - approximately 50 billion Euros - Hypo Real Estate annually requires short-term capital for refinancing.
+The king of kung-fu in Montreal
+"That is something quite special for me, I am Rapid offspring", Schrammel said.
+"The intervention by organized crime during the entire election process and especially yesterday is alarming, not just for Michoacan but for the entire country," Luisa Maria Calderon said in a radio interview a day after Sunday's vote.
+But now I can play computer games with shooting and it is not a problem for me.
+"More than 70 percent of adults in Burkina Faso cannot read," pointed out the disadvantage of written education Die Standard daily.
+The chairman of the Central Council of Muslims, Aiman Mazyek, expressed the fear on Thursday that religious conflict could also be brought to Germany.
+I felt the way homosexuals must have felt before the liberal legislation of the Sixties.
+Woman seriously injured by attempted handbag robbery
+The reduction of 55,000 jobs which has been taking place for three years is not yet completed.
+It must react instinctively and instantly because this technology corresponds to the most vulnerable and inner-most layer of the safety shield, a layer in which a crash is currently considered unavoidable.
+And she added: "No virtual operator is likely to appear in the T-Mobile network by the end of the year.
+He does not hesitate to reply that he would never accept a request from an unknown person.
+Climate: How France tampers with its promises of finance.
+Compulsory education?
+It is always fatal.
+He emphasized that the proposal included those consumer protection passages that he had supported, too.
+The ex President Alberto Fujimori was hospitalized Tuesday in a public hospital in order to be evaluated for the loss of muscle strength that occurs in the legs, informed his family doctor.
+The classic PC that defined the computer standards of the period, called IBM 5150, came to the market in 1981.
+The comparison to war is apposite.
+Biden does the best of the three on honesty, while Clinton's strength is leadership.
+And, in a match, it's easier.
+The 76-year-old filmmaker had fled the United States before his sentence had been passed for "unlawful sexual relations" with a 13-year-old minor.
+The relocated pavilion
+However the issue of liability for accidents and the security of drivers' personal data must be conclusively clarified.
+Pakistani authorities on Saturday zeroed in on the alleged mastermind of a plot to send five Northern Virginia men to Afghanistan to kill U.S. troops, saying they hope the case could help unravel an extensive network of terrorist recruiters who scour the Internet for radicalized young men.
+Bayona suggests that the answer to the question that gives the title of this piece is complex, because the contest rules lack a global view of Collserola: "16 cross contests have been called -he says-on sea- mountain sense, but there is no longitudinal reading, to see and understand the area as a whole."
+"This shows how much this is worth to us," says Wentzler.
+Republican leaders justified their policy by the need to combat electoral fraud.
+"We have done everything to contact them," said States Department Spokesman Philip Crowley.
+The ice cream university was created by the manufacturer of ice cream makers in 2003 to ensure that the ice cream from all its makers met exacting Italian standards.
+The Barcelona store includes a space with a pioneering pilot program at a world-wide level that is in charge with solving the possible problems of a computer science equipment of HP still with guarantee.
+Their situation wasn't helped by a recent BBC Two documentary, Wonderland: Young, Bright and on the Right, about student politics, which portrayed Tories as oddballs and neo-Nazis.
+After several months of discussions, the parties agreed in late 2009 to put the company up for sale.
+Agreement on the issues, and electability are also cited.
+For almost ten years the choir has been practising songs in this foreign, 'soft' language, and now and then they bring them back to where they originally came from: the South of Africa.
+"This is a traditional position that all governments have reiterated.
+The squatters, who had invaded 11 of the 13 floors of the building, the rest are inhabited- took all the wiring and part of the water, painted the walls and left residues of all kinds, especially alcoholic beverage cans.
+Rychytář does not care who his wife sleeps with
+Administrators at Penn State have been charged with perjury for allegedly covering up reports that a retired football coach was sexually assaulting boys.
+"The message is coming from a number which is not reflecting but it's titled 'death'," he told journalists after Mr Mugabe's speech.
+Solarworld came in 55th place among the 100 best employers in Germany in a study by the Great Place to Work Institute.
+As such, the experts debated, for instance, when the saurians split into the three most important lines of development: the carnivorous theropods, which later included Tyrannosaurus rex, the Velociraptor and birds, the four-legged sauropods known as the "long necks" and their relatives, and the plant-eating Ornithischiae (bird-hipped saurians), which included, for instance, the Triceratops and Stegosaurus species.
+Soldiers in this book have beehives fall on them; one has Christmas in Egypt under the pyramids; tsetse flies are an intractable problem.
+The injury was caused by a reckless tackle from Héctor Moreno in the 15th minute after the 20-year-old Shaw had burst into the PSV area.
+It distributed it in Anlong Veng in June as a supplement to the Education Ministry's high school history textbook, which contains fewer than four pages about the Khmer Rouge.
+Time passes, but poverty perpetuates from generation to generation in one of the hardest jobs in the world: the one done by human mules in the Kawah Ijen volcano.
+However, often they cause no pain or any other symptoms, thus remaining undetected.
+"They are being spattered with mud and attempts are being made to compromise them," alleged Mr. Putin.
+But since the Great Recession, Fed leaders have acknowledged that there's an unwritten third mandate: financial stability.
+The district's advertisement called for female applicants 18 to 22 years old, with a good figure and "the five facial features in proper order."
+Its decision-making process is "more art than science," said Zachary Karabell, head of global strategy for wealth-management firm Envestnet Inc.
+The other undergraduates giggled.
+Moreno suggests that students' peers, such as residential advisors, could monitor the site and intervene to help a student who posts one too many boozy status updates.
+Charles Schwab strategists believe the hike in rates will cause yields between longer- and shorter-dated bonds to move closer together, flattening the curve.
+"We will review all these paths, [which] are not exclusive, and the treaty with Nicaragua will require a conversation with Nicaragua" he emphasised.
+The other part will be paid according to the number of games played this year.
+At 18:05 the remains of Bacio Cortés (cremated), a citizen of Saltillo arrived to be given by the funeral home to members of the Mexican Air Force, led by Major James Martinez, on the esplanade of the training school, where he was already expected by his family, including his daughter Amanda and his wife Cristina, her mother, brothers and other relatives, students and teachers.
+Key events:
+Perhaps it sounds paradoxical, after all, we have three mobile networks here and over 100% coverage.
+The 48-year-old human rights lawyer and Chairman of the Egyptian Organisation for Human Rights (EOHR) defended the Muslim Brotherhood, when imprisoned or in court under Mubarak.
+The staff will drop to about 320 from over 400.
+But Putin's call upon the Kiev government to negotiate with the pro-Russia insurgents as equals corresponded with the apparent strategy he has followed since the violence began five months ago: Help the separatists take territory and force the Ukrainian government to grant the newly proclaimed Novorossiya region virtual independence to align with Russia instead of the West.
+"Roll up, don't be cheap, get your artwork"
+Fixed income also has been volatile as the market anticipates a rate hike, and the pattern is somewhat similar to what equities experience.
+Pardubice and Hradec Kralove region
+The Tokyo-based Fujitsu corporation sells itself as the third largest IT provider in the world.
+Otherwise, a project for one of the gates can crash into the program and definition with the project of the architect of the next gate.
+Something big was coming.
+This zest for like already beams out of Mr Li, he said flattering the host.
+He said: "We want to make religion more relevant to people in a post-Christendom society.
+Meanwhile, the Belgian, Dutch and Luxembourg governments partially nationalized the European financial conglomerate Fortis.
+My time finally came in the late '90s.
+Sylvain Simard let it be known that the four companies comprsing the consortium (BPR, Dessau, Group SN and Axor) are "well known to Quebec Liberal Party."
+On top of that, they must accept that the SIM card in their telephone is not registered under their name, and thus they cannot use all of its features like the regular customers of the mobile operators can."
+The latest wave of violence between Israel and the Gaza strip, as always, has sparked a lot of reaction.
+One possible prize-winner in the poll may be the last year's EU regulation according to which inflatable balloons must be sold with a warning that children under 8 years of age may not inflate them without parental supervision.
+"I have worked at a hospital where positive asbestos claims have been made," he says, "But I can't prove it in my case.
+While Breivik may have acted alone, he was far from alone in cyberspace: he had spent much of the time leading up to his attack at his computer, chatting with some of the millions of nationalists who support right-wing groups on social-networking sites.
+The authors of the study estimate the added value in the field of driver assistance systems and highly automated driving functions in Germany will be around €8.4 billion for 2025.
+"Personally, I think they are average-looking," Mr. Tang said, dismissively.
+After a first attempt by the guest captain Kauffmann who narrowly missed the goal from a far shot, Illhaeusern went on to take a slight lead and in turn Fonderflick from afar, then with Hirn from high, Romain with the tip of his foot or again Diebold came to tickle the Dannemarie defence.
+The "grand finale" of the Somerset House exhibition is Marie-Chantal Miller's wedding dress from her marriage to Paul of Greece in 1995.
+"Do you plan to wear the dirty socks tomorrow?"
+Over 19% of obese children had fried chips for dinner the day before the research connected to the educational event called Obesity is No Accident.
+Trump's favorability ratings have turned 180 degrees.
+Mr Kirchner, who continued to handle economic policy even after his wife succeeded him as president, was in the habit of drawing up budgets which underestimated tax revenues, economic growth and inflation.
+The CDU is taking besmirched walls as the pretext to criminalise the protest, said Janine Wissler (Left Party).
+It one of the most widespread formats and in addition to it, the absolute majority of devices can also handle music in WMA format.
+This is great advice for shooting on dry land, but it is even more important underwater because of the dim lighting conditions.
+"With the help of subsidies we have built a research and training center, we have enhanced our presentation at international fairs, won major awards in local exhibitions," says Žďárský.
+In a series, SPIEGEL ONLINE presents a selection of responses to the question, `What do you consider to be true without being able to prove it?'
+92% of new infections are through sex, 6% via the bloodstream and 2% perinatal.
+Then there's the question of methodology.
+At the fifth year, compared to the sleeve gastrectomy group, the bypass surgery group had lost more weight (18.7 vs 14.2 kg), achieved larger drops in BMI (7.4 vs 5.1) and in hemoglobin A1c (3.1 percent vs 2.1 percent) and were more likely to have complete diabetes remission (46.9 percent vs 16.7 percent).
+The work being done by experts from three institutions, the Czech Academy of Sciences, VŠCHT Prague, and the University of Heidelberg, is opening up the way to deal with the rthe virus' resistance.
+At the time he considered the city to be a degenerate hotbed of vice.
+Although it seems a pittance for such an inhuman effort, it is three times what he would earn in the field.
+"We followed the spirit of the times and this need for new means of writing, notwithstanding the rise of e-mail," explains Maria Sebregondi.
+"Certain parameters" were mentioned in the black-red government program.
+Draw
+There were signs she'd been beaten, and rigor mortis had already set in.
+The indoor temperature is very pleasant.
+The 15th week for the employment of the handicapped starts today.
+Breit got her interest in fashion from her mother, when she was still in the cradle.
+In addition, the project is also nominated for the Dutch National Wood Award 2012.
+Piffl: "Even I was skeptical at first.
+It is located 700 light years away in the Aquarius constellation.
+There are at least 15 versions of the balanced budget amendment in the House alone, and another handful that would "control federal spending."
+The social foundation is moving down from the mountain into the town centre.
+Luciano warns against letting the spirit of the age lead you astray.
+In August, defeated presidential candidate Mehdi Karroubi said some protesters detained after the election had been tortured to death in prison and others had been raped.
+The oldest of his five children, 30 years old, also works carrying sulphur.
+It is essential and legitimate to look for the best fan of energies for our country, but it would be irresponsible to allow emotion, dogmas and partisan manoeuvres to dominate the debate, which is so decisive for the economic, social and financial situation of our country.
+Knowles said Prentiss, who had a hound dog named Lightning, had been dating Lamb for about three years.
+Asbestos has been, and in many cases still is, embedded in the homes we live in, the offices we work in, the schools we are educated in, and the stores we shop in.
+"It was always in the back of our minds that the Müllers would fit into this practice well," says Dr Ursel Felstehausen and laughs.
+Injured people at punch-up in fast food restaurant
+Last week, leading fund manager Hamish Douglass, the founder of Magellan Financial Group, told a business lunch in Melbourne that Metcash could "highly, probably disappear within a decade.
+"I always thought that Wuffli and Ospel were a dream team," says the banking research, Hans Geiger.
+The conflict between the union and the airline had led to a number of strikes over the past months.
+It's hard to see them breaking a leg to help the Selfie Brits, whose energy might be better spent preventing Scotland leaving the UK - something they don't want either because most have similar separatist tendencies.
+Pluralism and Pragmatism in a Secularist State.
+"The evacuation of this morning was disgusting and shows that deep inside Bloomberg is more interested in preserving the financial interests of American workers," added the spokesman of the movement, who accused the mayor of "disrespect for the freedom of expression."
+It asks employees how happy they are with their work and job environment and looks at the general working conditions.
+Coupon checked by self-service machine instead of driver
+"Beer pong" is the name of the bizarre spectacle; the winner gets 500 Euros win bonus plus plane tickets to Las Vegas for the beer pong world championship in January.
+Moreover, it should be noted that the country yielded to the principles of the United Nations Commission on International Trade, that is the rules set for cross-border insolvency cases, ensuring fairness for debtors and creditors.
+Although the motion on Europe devotes a paragraph to the importance of "Franco-German friendship," Angela Merkel did not mention France.
+Esme Nussbaum lowered her head.
+One of them could be Geely, which aims to acquire Volvo, but the option of the Dutch sports car manufacturer Skyper, which is funded by the Russian group Converg, is gaining momentum.
+Indeed, she has had frontline experience of her own.
+So what specifically does a "normal" foreign policy entail, from a German perspective?
+Hungarian officials also closed two of seven border crossings with Serbia on Tuesday morning after deploying a train car covered with razor wire to close one of them.
+Most often, Czechs spent their holiday at home, which resulted in great number of cottages and summer houses, a habit that survives until now.
+In Vienna, there is word that the Syrians were afraid of some kind of fishing expedition and worry that the IAEA is being sent out by the USA as a vanguard to spy out military facilities.
+Because the poll has been taken regularly since 1995, it tracks changes in attitude across the region.
+It may also clustered people in groups of conversation.
+Our advice on how to choose
+When it was in the dressing room he had an oxygen mask on.
+Tens of thousands gathered on Friday evening at the Tahrir Square in Cairo, in unfamiliar unity, and pledged to bring down the charter before it has even come into effect.
+Pfc. Elizabeth Lyman was 25 years old and 11 weeks pregnant the night she says she was raped by a fellow soldier.
+The Secretary Dionisio Perez Jacome gives details of the crash where the Interior Minister, Francisco Blake, and seven others died.
+The choice of Berlin will result in a rise of the price of electricity, an increased energy dependence aggravated by increased recourse to imported gas, in particular from Russia, a jump in carbon dioxide emissions due to the construction of gas and of coal centres.
+Long before he led the revival of Apple, Jobs presciently foresaw the ways in which so many industry leaders would stumble in their vision, and lose control of their market share.
+His lifestyle, however, has remained humble,
+In the means of investigation it is emphasized that, for the moment, no data has been found related to the persons arrested in Catalonia regarding the attack of Bombay, although the author of this attack, " Laskar e Taiba" , has been one of the receiving groups of the passports robbed in Spain and soon falsified in Thailand.
+Basketball globetrotter Hector "Hetin" Reyes was involved in the sport for over 60 years and, thanks to it, travelled the world.
+They are currently working on a fashion boutique in Gelsenkirchen.
+Around the supplies stand located in the meadows of the castle garden, people from Salzwedel, but also guests from near and far, made themselves at home.
+The announcement came from the company as a reaction to the harsh criticism of their salary policies.
+The response has been underwhelming, family planning officials say.
+"I wore lots of hats in basketball throughout my life, including several at the same time, like when I was president of the BSN, general manager and federative president of the National Team during the '90s," recalled Reyes during Primera Hora's visit to his home in Bayamón, where he lives with Isabel, his loyal wife for over 50 years.
+The small house is in a classy neighbourhood with tended front gardens. Large, expensive cars are parked in the driveways.
+In fact, it comes from a single meeting of 12 people convened to develop a multi-criteria decision analysis (MCDA) model to synthesise their opinions on the harms associated with different nicotine-containing products; the results of the meeting were summarised in a research paper.
+Every day BBC News - on TV, on radio and online - brings you the latest stories from across the globe... but what we want to hear are the issues that matter to you.
+Together with The Tap Tap band, we tend to joke about it, saying that we might be the only band on earth that could draw enough positive energy to hold off or avert the end of the world completely.
+When the ground is wet, water diffuses inside the covering and it's hard to get out, this causing a softening of all layers of the pavement and, therefore, the formation of potholes.
+However, Hašek's era sees football back in quarrels between both association chambers, unable to agree on a common candidate.
+"The quality of these particular customers is pretty strong."
+`It could be dark matter existing very close to Earth that may be responsible for the anomaly,' he writes.
+What is private offline is private online
+This will provide high-speed internet access to 400,000 people and will provide work for the German firm for 18 months.
+Since this is the layer that will be in contact with the wheels of the vehicle, it must have a better mechanical strength than the asphalt covering and provide road friction.
+With each of the nine teams
+On the agenda is the fate of unconventional measures of support for countries of the Eurozone in the market collimator (see above).
+Another republican who was in favour, John McCain, has not defined his position at this moment.
+Among the most vulnerable to new infections are teenagers.
+This was said by Miloslav Kala, vice-president of the Supreme Audit Office (NKU) in an interview for Aktualne.cz.
+I think it's partly because we have nine discs and we can play more than 120 songs and everyone likes different songs, so it's difficult to choose which songs to play every night.
+I saw some things there and came out stronger.
+They had agreed to a ransom,' the agent said.
+No confirmation could be obtained from AIG.
+Stars who lost their mojo
+"I want to avoid all kinds of representative nonsense, as at the previous general meeting," says the owner of Viktorie Plzeň, who is a candidate for the first time; and in his statements he chiefly stood against Pelta.
+Tymoshenko claims the verdict is a political revenge of the regime; in the West, the trial has also evoked suspicion of being biased.
+Since you're starting uni at the height of Bake-Off mania, knocking on people's doors to introduce yourself with a plate of brownies seems marginally less weird, less 1950s "Welcome to the neighbourhood, I baked you something, now smile as I ask you personal questions."
+Even though I had timed the chore to coincide with the late afternoon lull at my local branch of JP Morgan Chase, a queue of 20 or so people was already waiting in line.
+Conversely a British soldier realizes that he will most likely die, and that no one will notice or care.
+Sreekanth Chalasani, a researcher at the Salk Institute in La Jolla, California, told the Guardian that the procedure could one day replace deep-brain stimulation, an invasive procedure that delivers electrical pulses into people's brains to treat symptoms of Parkinson's disease.
+Apparently not enough security guards had been booked with the security company.
+I'm not someone who likes to talk in front of other people, mind you, let alone a class of 40.
+But the Texas native brushed aside her concern.
+However, despite what he says, Morgan Freeman is proud of the new film.
+The prime minister does not exclude calling for an election before the end of the year
+And he explains why he is pacifist; what lies behind his criticism of society; his political heart and soul; and also how his thoughts and ideas have been shaped and moulded - not only by music (he was an opera lover who became a soul and rock musician) but by his prison experience, too.
+Saleh al-Somali was one of two Arab men thought to have been killed when a pair of missiles tore into their car Tuesday near the town of Miran Shah in North Waziristan province, according to U.S. sources and Pakistani officials in the region.
+New cars that fall under the emissions class "Euro 6" will receive a higher nitric oxide value.
+Minister of Education, Youth, and Sports, Josef Dobeš, would like to force the split parties inside the strongest sports association in the country to reach an agreement.
+M. Monti, known for his competence and for his independence when he was European Commissioner (1994-2004), represents a "change of epoch" for Italy after 17 years of "berlusconism," the "professor" symbolising "the challenge of seriousness" and "another Italy," according to the leaderwriters.
+Here are some recent poll numbers that suggest that the real estate mogul isn't just a passing phase:
+He allegedly attempted to manipulate the current tender for the settlement of restitution claims, so that the land offered was awarded to a particular candidate.
+The impact and dimensions of Stuttgart 21 cannot be overestimated.
+Goalie Petr Cech prevented a potential own goal from Tomas Sivok in the 9th minute with a split-second reflex.
+When Justin Bieber drinks coffee people goggle through the window.
+Its inventions include, for example, the cash point, pay card, financial swap, bar code, and floppy disc.
+Another communication dated Janaury 2008 and signed by ambassador Wilkins, warns Washington about the increasingly negative image of the United States conveyed by drama series broadcasts by CBC.
+"I don't know if they answer me, I only upload them" he adds.
+On Monday, the microblog site Twitter introduced changes in the presentation of its platform, to allow its users, in particular, to observe the activity of those whom they are monitoring, which makes its service resemble that of Facebook.
+Whether the current smog in the city state will have any influence on the Grand Prix in Singapore is as yet unclear.
+A tweet on Shaw's account read: "Thank you everyone for your messages, words can't describe how gutted I am, my road to recovery starts now, I will come back stronger."
+The defense has said it plans to have Manning plead guilty to lesser offenses and fight other charges as being too extreme.
+Of the seven lophoscopists working in the branch of CTI, this week it was the turn of "availability' for Eleazar Gonzalez, a man of Puerto Tejada, who had spent 21 years working in the area of judicial investigation.
+Konstantin Vassiljev equalised for the away team in the 57th minute.
+The engineers could not get a half-decent sound out of it.
+In the letter dated from 2003, Liliane Bettencourt added, according to the lawyer: "could you explain to my daughter that I wrote to Mr. Banier once or twice a day for fifteen years."
+In the opera category, the nominees are Berg's "Lulu" from the Orchestra of the Royal Opera House; Adolf Hasse's "Marc Antonio e Cleopatra" from Ars Lyrica Houston; Kaija Saariaho's "L'Amour de Loin" from Deutsches Symphonie-Orchester Berlin; Rodion Shchedrin's "The Enchanted Wanderer" from the Orchestra and Chorus of the Mariinsky Theatre; and Arthur Sullivan's "Ivanhoe" from the BBC National Orchestra of Wales.
+It should read: "Here lies the honest citizen JR Ewing."
+Being cigar-shaped, it is introduced inside the 1-metre wide pipeline, and it is pushed along by the gas.
+He was once a footballer but now Tim Wiese, ex-national goalie for Germany who also played for Bremen and Hoffenheim, is a wrestler.
+Charity CMT UK said that misdiagnosis is a common problem among people with CMT because so little is known about the condition.
+Even if the ceasefire agreed on November 21st holds, this week's fighting has strengthened the hawks on both sides.
+"The walls are difficult because they are not suitable surfaces to get a print, but in this case we could get the print of the whole hand and identify the offender, who had participated in several robberies" he said.
+So, the KMT tends to avoid parading its ties to the government in Beijing.
+According to him he wanted to put on 30 kg of muscle mass in the past two years.
+And for a good cause.
+At Japanese schools, the bentos aren't just lunch.
+He was certainly a designer, dreamer and self-identified hippie, but he was also a meticulous organizer and flow-chart tweaker - a man who believed that many business executives suffered from "a disease of thinking that a really great idea is 90 percent of the work... [but] there's a tremendous amount of craftsmanship between a great idea and a great product."
+"Overall, we found that there has been working on, we believe it is necessary to develop a long term program that redefines the vocation and the economic course of the state, it is important to detonate all the material and human potential resource that Sinaloa has," he said.
+The Müller couple liked the idea of running their own practice in Asendorf in the future.
+FedEx earnings mixed, lowers fiscal 2016 outlook
+Unfortunately, the Czech regulatory organs have been tossing the whole case back and forth like a hot potato.
+UNAM asphalt would avoid potholes
+A ticket for any type of city transportation costs 6 shekels, and you can ride for 1.5 hours with transfers.
+The choice depends entirely on the manner of use and demands of the future owner.
+The departure of French combat troops was completed on 20 November.
+Most of those ahead of me, I was to learn later from Starr, my "licensed personal banker", were lining up for the same reason as me.
+If opposition members enter parliament, it is because they have been appointed, not elected.
+Salvador Barraza Rubio, president of the Association of Retailers of the Zone Dorada, remembered that in different occasions they have denounced that the image of the destiny should be taken care of and to change the bad perceptions that the tourists might find with new activities or routes.
+Automated and networked driving will increase traffic safety and ensure fewer traffic jams, said Dobrindt.
+Tawa Hallae looked like many other carnivorous dinosaurs: The animal, standing two metres tall and with a length of 1.50 metres on two strong hind legs, had a longish skull with sharp, curved teeth, short arms with sickle-shaped claws and a long tail.
+Canadians are living half dead, according to a report of the Royal Society of Canada
+Martin was still a teenager when she had him in 1931 during her marriage to lawyer Ben Hagman.
+An extra flight that was to take, among others, the Vice Presidents Dalibor Kučera and Rajchl to Podgorica did not leave Prague in the morning due to a technical failure. An alternative was sought for in order to transport part of the executive board to the scene of the barraged rematch.
+"Terror of the Galician woman (inscription)."
+"They were brought up with no concept of doing business."
+Critics assailed the project as promoting both terrorism and traffic tie-ups.
+Its leaders had warned prior to the verdict that the representatives would leave Parliament rather than take their seats as representatives with no affiliation.
+This, it must be said, still has huge shortcomings, offering no explanation for gravity (oops!) or dark matter, which forms approximately 80% of the matter in the Universe (re-oops!).
+The pressure turns a turbine which in its turn fuels a generator.
+This amounts to a shortfall of 140,000 homes.
+While he was last seen smashing a racquet after cramp foiled a potential US Open upset of Richard Gasquet, Kokkinakis has been defended staunchly by Healy.
+Shares in Glencore rose 5% after the mining giant said it had raised $2.5bn through a share placement as part of its debt-cutting strategy.
+The debate continued on the newspaper's website.
+It is still a priority that anyone wanting to claim asylum can "of course" do so.
+"But it is possible."
+He told Radiožurnál that he was halting the campaign for Christmas and would restart it in the New Year.
+But in something of a twist, "those who combine their online activism with offline activism are more reasonable, more democratic and less violent than those who just remain behind the computer screen."
+`Not everything was fun to look at today,' Marcell Jansen later admitted.
+The deal was disclosed in a joint statement issued after Secretary of State Hillary Rodham Clinton met with Belarusan Foreign Minister Sergei Martynov on the sidelines of a security summit here.
+The close supporters of Carod demand the president something more than putting his position at the disposal of the militancy, a gesture that is not worth when Puigcercós controls the most important organ between congresses.
+Arizona, USA,is home to the Large Binocular Telescope.
+The drama series on CBS about the Ewing clan and other characters in their orbit aired from April 1978 to May 1991.
+"It is a fundamental issue we cannot exist without," Pelta claims.
+"Japan, like the rest of the world has its eyes riveted on Europe and the exchanges will chase one another in a corridor of narrow variations as investors will not have proof that the situation has stabilised," states Mitsushige Akino, fund manager at Ichiyoshi Investment Management.
+He said some kids are drinking sanitizer intentionally, while some do it to impress their friends or on a social-media dare.
+According to the weather service Meteomedia, Saxon Switzerland was put on red alert - the highest alarm level.
+They is psychotic, she was, after all, questioned more than once.
+Success is there.
+The office of minister Aleš Řebíček hopes that it will discourage drivers from behaving dangerously behind the wheel.
+The England head coach, Trevor Bayliss, praised his attitude even when he was not performing as well as he can and that does not surprise me; he is a team man above all else.
+This characteristic also connects many with the billionaire who wants to become US president.
+Bieber himself, whose new album is due out in November, is not interested in all those zeros.
+The representation should be the shopping window of football.
+Two hundred to 400 thousand, which I still do.
+The last man, who lived with her, declares his grief for feeling guilty.
+Architectural design company, Arch.Design, whose studios produced a number of important buildings in Brno, have included the space for their corporate tiny kindergarten even in the first drawings of the Avriopoint building.
+The fact that the influence of former Securitate members is still very big in Romania was proven after the announcement of the Nobel prize for Herta Müller by an interview, in which a former Securitate head from Timisoara spoke in derogatory terms of the prize winner.
+Savers could see gains as well through higher yields at the, though experts differ on how quickly that will take hold.
+"However, many people told me I mustn't give up, otherwise others would follow."
+One of our main goals is the Champions League: we qualified for the last 16 in the right way.
+Even though most data show the economy growing solidly, the recent turmoil in global financial markets could make already-cautious Fed officials skittish about adding to the volatility by raising their benchmark federal funds rate - even by no more than a mere quarter of a percentage point.
+The two far-Right parties that captured almost 30 percent of the vote, the Freedom Party and the Alliance for the Future of Austria, have campaigned on an vehemently anti-immigration ticket and some of their slogans were deemed xenophobic by critics.
+Peek and Rickard, who live in Redding, are in town for the AKC/Eukanuba National Championship in Long Beach this weekend, where they planned to show Trace.
+According to this a "gable roof with an off-centre ridge and roof overhang" will be constructed.
+I think you have something a lot less life threatening.
+This ground-breaking legislation will give workers the same legal options for union organizing discrimination as for other forms of discrimination - stopping anti-union forces in their tracks
+The one recorded in the second quarter, for the Japanese the Fiscal Year begins in March 2012 - represents also the fastest rhythm of growth from January to March 2010.
+Sitting side by side on the tribune of the auditorium of the Stade de France, Georges Leekens and Eden Hazard made peace.
+Certainly, most of you have been told talked in your sleep.
+The couple also have two grandchildren and enjoy travelling.
+The highlights: mannequins which look alarmingly human thanks to video projection.
+There is much at stake, as South Australia and Western Australia account for almost 30 per cent of Metcash's IGA store footprint and generate higher profit margins than Metcash's IGA network in the eastern states.
+In France, the start is more modest; 400.000 contactless Visa card are in use.
+Ludwik Sobolewski, President of the Warsaw Stock Exchange confirmed the bid that has been taken by the Polish, in spite of the fact that the Czech had previously excluded the Warsaw Stock Exchange from the group of potential owners of the Prague shares.
+Multinationals with lots of debt will fare worse, as a rising dollar makes their products more expensive in the global market space and their debt more expensive the finance.
+Kovalev gained the victory by scoring the only goal of the shootout.
+Earlier this week Salman vowed to reveal what caused the crane to topple into a courtyard of the Grand Mosque, where hundreds of thousands of Muslims have converged ahead of the hajj pilgrimage later this month.
+Moreover, he says his motivation is to continue the work he started with Hašek.
+It is part of a revitalisation project, which also includes an underground car park, a supermarket, a post office and a small number of adjacent apartment buildings and terraced houses, with a total of 50 dwellings.
+The premier of the Amula-Open-Airs was more than a success in terms of the number of visitors.
+But how to find them?
+The last sixteen of the Champions League (first leg 16/17 + 23/24 February/second leg 9/10 + 16/17 March) will be drawn in Nyon on 18 December.
+That list included the F35 Joint Strike Fighter, a planned new bomber, the next-generation ballistic submarine, the new littoral combat ship and the new ground combat vehicle the Army and Marines need to replace the humvee.
+Due to the slump in the housing market, young adults of necessity live longer in "Hotel Mama".
+There will have to be talks in the coming days with Brussels and other countries," Ivica Dacic said in Prague.
+Consumption alone was a spur to the economy in the early part of the year, whilst investments were down.
+The owner of the club says that the invaders of the farm made ​​her an unfair competition, since they were selling drinks for three Euros, while in the club worth 10.
+In collaboration with the Société internationale d'urologie [SIU], Movember has created a tool that makes it possible to evaluate the pros and cons of the PSA test.
+The only candidate who beats him?
+The only exception was the period from 1962 to 1972, when we had the opportunity to travel to Yugoslavia. Nevertheless, the Yugoslavian regime turned West, which caused significant limitations to trips to Yugoslavia for Czech tourists.
+The 20-year old tells us there are "three in the eight to twelves, six in the twelves to 15".
+When the United States occupied Japan after World War II, General Douglas MacArthur and his aides encouraged the country to adopt a constitution designed to assure that Hideki Tojo's militarized autocracy would be replaced with democracy.
+They describe how the Elysée explained its strategy to the Americans, going so far as to give them advice on the treatment of their own "hostage" in Iran crises (a small group of trippers).
+The report details the gains, which every country would achieve through this international programme.
+And then the words "you pay" are in a pool of blood.
+Freeman said that he had asked ninety-one-year-old Mandela if he could play him in Eastwood's film.
+Indeed, the best way to understand what Ellison, Lewis and the cosponsors of their legislation are proposing is as a reconnection with a very American idea.
+"The conflict has increasingly become an economic competition," Mr. Englund writes, "a war between factories."
+In comparison, 260,000 units were completed in this year in Germany.
+In the north of the country, at an elevation of 1600-2040 m, there is a famous ski resort called Hermon, which fills up with tourists in winter months.
+"Only my name is thrust into the forefront," says Lukáš Pytloun modestly today.
+"Throughout the years in business, I'd always ask: "Why do you do things?" and the answers you invariably get are: "Oh, that's just the way it's done.""
+While lurking in the other are the bosons, a nasty band of anarchists who respect nothing - at all events, not this principle, which means that they can indeed be found in the same place at the same time.
+Probably there is not a more appropriate place in the world than Paris to present a fashion award, and probably there is not a living designer as exquisite as Valentino.
+In the fight against Ukrainian government troops, pro-Russian separatists say that they have once again shot down a warplane and two military helicopters.
+Bousquet bested the Croat, Duje Draganja (20.70) and the Russian, Sergey Fesikov (20.84), but he did not manage to reduce the world record time (20.30) as he had envisaged.
+Justin Bieber in the capital city: on a Bieber expedition in Berlin
+Within the construction project at the Jedlicka Institute, a separate building is planned, which we can move into with this project.
+The body of a young woman was found on Tuesday evening in Rockenhausen near Kaiserslautern the public prosecutor's office and police reported on Wednesday.
+Thus, proposes a reform of the statutes that allows celebrating the congresses through delegates chosen by suffrage.
+Companies in the District, Maryland and Virginia collectively forked over $10 billion in state and local property taxes last year, up from $9.6 billion in 2012 - year-over-year growth of 4.2 percent.
+Now everyone knows that the labor movement did not diminish the strength of the nation but enlarged it.
+"I was terrible for me to hear some of them say that at this point, they don't even want to identify themselves with Czech football."
+According to the German Federal Statistical Office, however, in the last year fewer than half of all asylum seekers have lived as tenants.
+Watson led the company until 1952.
+Traffickers move towards Germany over minor border crossings.
+By raising the living standards of millions, labor miraculously created a market for industry and lifted the whole nation to undreamed of levels of production.
+"But the idea is that it is not the price which is impportant, but people's skills" stated M. Laporte.
+Joan Rivers has been unconscious since her arrival three days ago at a New York City hospital, but her daughter expressed hope today that the 81-year-old comedian will recover from her illness.
+Ethics experts said the unusual arrangement between Mr. Ensign and Mr. Hampton, who were close friends before the affair, appeared at odds with the so-called revolving door lobbying ban.
+He said Lamb made the fateful 911 call sometime after that.
+However, the judge's ruling means that for the time being doctors can continue to perform legal abortions while seeking such privileges.
+Ir rests on the bottom of the sea, at an average depth of 200 metres.
+According to the English press, the government to endorse all outstanding loans in the bank Bradford and Bingley, including more than 41 billion (75.5 billion U.S.) in real estate loans.
+However the refugees in Germany are not being systematically asked about their qualifications so as to be able to help them get started, criticised Claudia Walter, project manager for integration and training in the Bertelsmann Foundation.
+We don't look like orphans, we're not little children, was how he reacted to the question of whether the ODS was not hampered by the presence of the party chairman in the parliament and in the Czech Republic during the political negotiations regarding the budget.
+Experts believe shoppers could be holding off making purchases ahead of the event, which takes place on the last Friday in November .
+The CTMO trademark office then also dismissed the Munich-based company's appeal.
+A few hundred Belarusians gathered on Sunday evening at the closing of polling stations in the central square of Minsk to protest against the fraudulent elections.
+Renzi hopes, not least, to be able to thus quieten the left-wing party basis which is always stirring against him, for Mogherini is considered to be one of their group - albeit one of the more moderate.
+As for Richard Jaubert (CGT), he described it as "an acceptable compromise".
+The defendants were not able to provide accurate documentation for the earlier years.
+"A great amount of work was done in those two years, and I don't want to throw it all away."
+Hamburg -
+In large amounts, it increases the risks of developing colo-rectal cancer.
+We have already written many times on Mobil.cz about the fact that Czech operators are among the most expensive in Europe.
+On the opposition side, the outline of the Northern Plan was received with scepticism.
+He also promised to solve the Bohemians case; improve relations with both UEFA and FIFA; bring more money to football; and continue the work of the previous President, Ivan Hašek.
+The report was critical of White House officials, lawmakers and the former Attorney General Alberto Gonzales.
+The 19 participants of a desert expedition were already on their way to Cairo, it said.
+Congressman Olvera admits that after 12 years outside the presidential palace of Los Pinos, there is much expectation within the party about Enrique Pena Nieto.
+The vast majority will move with Fischer and the internal medicine ward that still continues to exist to Schongau.
+Replying in the afternoon, the Minister of Natural Resources Nathalie Normandeau, denied vigorously any collusion in connection with this contract.
+Hepatitis: when shall we turn to a doctor?
+Many areas in the country have no doctor – Asendorf by contrast is fortunate: on 1 October Dr Frank Müller is taking over the Felstehausen practice.
+Karl März and Adolf Ried led the club as range officers during its tough early years. The main objective then was to find a club pub and set up a shooting company.
+The boardroom is now contemplating the possibility of working together.
+The artist was in Florida at the time of the incident, the Associated Press news agency reported.
+He has also played in only 65 of Arsenal's 157 league games during the last five seasons.
+Piraeus had won their six most recent premiere class home games, including against prominent clubs such as Manchester United, Atletico Madrid and Juventus Turin.
+We're trying to implement a game project.
+Ha said Zico had sold up to 6,000 to wholesale outlets and was awaiting new stock.
+The head of the bank then plans to announce changes following the investigation at the end of January.
+He was legally acquitted of this charge in May.
+Commodities trading may be reduced or stopped completely.
+"They want to go out but they have in mind the price situation," he mentions.
+Experts fear that Albert Einstein's general theory of relativity may not be entirely correct.
+B&Q boss says Eastern European tradesmen working cheap is behind trend
+The rocket was designed as a two-stage rocket, with a total length of 510 cm and a launch weight of 32.5 kg.
+FC Eintracht Bamberg moved into the last 16 with their victory against district league no. 1 FC Oberhaid (3:1) and at home against regional league no. 1 FC Schweinfurt 05 (3:2).
+And on the other hand, where do we still lag behind more advanced countries?
+The executive committee has refused to enter into the necessary discourse.
+Perhaps the most unusual pool design awaits bathers in Längenfeld. The Aqua Dome in Ötztal looks like a UFO has just landed in the Alps.
+The new unity does not create unanimity
+Assists of Jágr and Voráček Helped Philadelphia's Victory
+On Wednesday, Quebec Flood Forecast Centre issued flood warnings in respect of several rivers, in particular Maskinongé, Assomption, Ouareau, L'Achigan, Batiscan and Loup.
+Many smokers in Australia remain defiant.
+The architect Adolf Krischanitz has now renovated the pavilion, which has been named the "21er Haus" and will be used as a contemporary art museum.
+The word was not included in the previous Constitution.
+Due to Mario Pavelic's recent pelvis injury, Schrammel moved from playing left back to right back, where he also did a very good job.
+They were able to partially limit the damage.
+The verdict of the judges was unanimous.
+UBS was a major player in foreign exchange and stocks.
+It's part of the essential vocabulary of Japanese girls and means `cute,' `sweet.'
+"What happens if my personal data are used against me, if it is discovered what I do?", ask some of the users worrying about the information-monopoly of Google.
+It remained one of the seven state symbols even following the creation of the independent Czech Republic.
+Of course these lessons are very different from those at a proper school.
+In the following year, the PTA's first chairman, Kazimierz Zarankiewicz (1902 - 1959) was appointed Deputy Chairman for the International Astronautics Federation.
+The teaching staff demand the immediate termination of the criminal prosecution.
+The benefits of weight loss surgery for mildly obese people with type 2 diabetes can last at least five years, according to a new study.
+A rocky footpath leads up to the somewhat 600 year old oak tree.
+Gates, who was to return to Washington late Friday, met in the morning with Iraqi Prime Minister Nouri al-Maliki before flying to Iraq's oil-rich Kurdish region for meetings with troops in Kirkuk and Kurdish officials in Irbil.
+"We often had to find a material that was good, cheap and met with the approval of the monument authority," says Krischanitz, pointing to the rough flooring in the basement.
+WestLB would contribute to the deal a `bloc of expertise' with sustained earning power, it says.
+"This is where this paper is critical, because it says this surgery is safe in that lower BMI group," with no increased risk of death or renal disease, she said.
+In smaller cities the prices are lower in absolute terms, but they have a higher impact on the local economy.
+But in any case, the balance is not there, observes Jean-François Forget, general secretary of UFAP.
+We need to let the computer world into our physical world, make it more tangible.
+Since this does not yet exist, construction plans are still subject to variation.
+Lack of Scots title race bores Dutch - de Boer
+It is inexpensive and saves time.
+That's important because they will be less likely than other airlines to cancel or delay airplane orders when fuel prices rise, Dihora said.
+They will have to give up their current relationship with Iran; they will have to give up their relationship to the (Shi-ite movement) Hezbollah; they will have to give up the ongoing support they provide to the terrorism of the (Shi-ite movement) Hamas, (the terrorist network) Al-Qaeda and the jihad (holy war) in Iraq," the prime minister specified.
+It's an immense body, that occupies 70% of the planet's surface and now the big, international energy companies are discovering it.
+That's not to say there won't be effects, however.
+However, there are tougher gossips, women who enjoy frequent gossiping and despise everyone. They are, especially within a female work team, very dangerous for their surroundings.
+With all the risks.
+Fast food restaurants increase it with time, but very little. On average their ordinary employees in New York earn 8.90 dollars/hour.
+Incidentally, it is the most unusual sea in the world, located in the lowest point of the planet - 417 m below sea level.
+SuperCamps confirmed that the text was provided from Cameron's staff, but had no further immediate comment.
+Entry is free of charge, and contributions are strictly not allowed.
+Precisely why our brain plays such tricks on us, is still puzzling to scientists.
+Deutsche Bahn has come up with a crisis plan to prevent train cancellations in the winter.
+The disclosure of the U.S. Embassy memo, which didn't occur until late evening Moscow time, is sure to stir displeasure within the Russian government, although to the extent that Luzhkov can be blamed for Moscow's failings, it might be an opportunity for the Kremlin to argue that it is solving the problem.
+There was no answer to this for a long time.
+Such was the work of the person who identified the body of Alfonso Cano
+The US air strike ordered by the German Kunduz commander Colonel Klein, up to 142 people were killed of injured, according to the NATO inquiry report.
+On the other hand, the administration does not often ease their life.
+He told Czech Radio earlier that he had intentionally selected singers with young, representative voices that were striking and popular for the solo variants.
+Poland may soon have a nationalistic government of the right, Spain one of the left.
+One more check of more than 200 thousand pesos in favour of Lorena Guadalupe Camacho Palazuelos was issued by the City council.
+She can even feel his presence, at least for some moments.
+The NCUA chairman, Debbie Matz, welcomed the responsiveness of the two banks.
+Between January and October 2012 118,800 Ukrainian tourists visited the Holy Land, which is 51% more than a similar figure in 2010, before the removal of the visa regime on February 9, 2011.
+According to the dancer "we do not pretend to tell her whole life, but to collect her spirit.
+So far, the state has been paying around 500 thousand crowns a year on all general vaccinations for children.
+The amount greatly exceeds the price of admission to other Gaudi's buildings in the city.
+Deutsche Bahn has also been forced to have the axles of ICE trains checked significantly more frequently for many years, after an ICE train's axle broke in Cologne's main station.
+The weather, especially humidity and temperature variations are also a very important factor to consider, especially water, he said, because it greatly affects the performance of the asphalt.
+Other applications could be within the aerospace industry.
+Five hundred American journalists have been asked by PEW Research Centre what they think of the state of their profession and mental control as regards to the future.
+Survey that removes absurd regulations
+This has done little to calm fears in Anlong Veng.
+Polls and analysis conducted immediately after the elections, which established the far Right as the country's strongest political bloc, indicate that the change was brought about by predominately young voters who are concerned about their future in the European Union.
+And, among the possibilities that are contemplated, the one of leaving a monetary zone of little serious countries cannot be excluded.
+Tolerated, sometimes assisted, by local insurgents, the latter will no longer be so when Westerners become more scarce.
+"The first hike from the Fed since the global financial crisis will inevitably be interpreted by some as signaling the end of the era of 'cheap money,' " Julian Jessop, chief global economist at Capital Economics, said in a note to clients.

--- a/calibration/translation/calibration_data.tok.bpe.en
+++ b/calibration/translation/calibration_data.tok.bpe.en
@@ -1,0 +1,500 @@
+His efforts were un@@ successful , but did insp@@ ire locals to begin planning a ton@@ gu@@ e-@@ in-@@ che@@ ek Ben C@@ ous@@ ins bi@@ ath@@ lon .
+His third album , &quot; Gre@@ etings from Mich@@ ig@@ an : the Great Lake State &quot; , released in 2003 , features cle@@ ver@@ ly composed songs which cling harmon@@ ically to the traditions of American folk rock of the late six@@ ties , but which might dri@@ ft at any time into amazing op@@ ul@@ ence .
+She also wants to use the EU environment better , and get more Cze@@ chs into European institutions .
+or with a white ice cream base that can be turned into yellow cream by using eggs or can be mixed with co@@ coa powder to form the base of all kinds of se@@ duc@@ tive chocolate .
+In the letter , Germans from Č@@ es@@ k@@ ý K@@ rum@@ lo@@ v request that the American president not to allow the return of the &quot; Š@@ u@@ ma@@ va region &quot; - occupied by Hitler on the basis of the Munich Agreement - to Cze@@ cho@@ slo@@ v@@ akia .
+&quot; He is a person who can listen to all twenty-@@ seven member states , communicate with them perfectly , and who has a clear vision of where the EU should be headed . &quot;
+The group compla@@ ined that the sums quoted in the broadcast@@ s were not accurate .
+Cuba : hundreds of Government supporters speak out against the &quot; Ladies in White &quot;
+N@@ ine years later , the 30-@@ milli@@ on-@@ euro mountain has been lifted up .
+Z@@ el@@ aya &apos;s departure attempt from Hon@@ duras to Mexico abor@@ ted
+Also , I think you can be a happy person and still be able to make music that is dark .
+Czech army has purchased 4@@ 45 kilometers of cor@@ ds , which de@@ ton@@ ate explo@@ sives .
+On how to spend the rest of the 700 billion dollars will be decided by the Congress .
+Taking into account the large exposure of European banks to sovereign debt markets of the Euro zone , the issuing institute has no option other than to maintain a presence in the market .
+In the major cities there are multi-@@ level department stores that sell counter@@ f@@ eit goods almost exclusively .
+&quot; The number of such institutes will be growing ; it will be a highly two-@@ speed Europe , &quot; Vic@@ en@@ ov@@ á expects .
+The trail of the Stuttgart stones leads to a forest in T@@ ü@@ bin@@ gen and a former French muni@@ tions de@@ pot where Manuel Ron@@ gen has created his own world of stone .
+I just know what those people feel , the hor@@ ror of it .
+More flav@@ our@@ ings , more fruit pur@@ ée - not necessarily an improvement in taste .
+It will be done &quot; in a very short time &quot; , assu@@ res Mr. Bus@@ ser@@ eau .
+&quot; Six@@ ty-@@ six parent coordin@@ ators were laid off , &quot; the draft complaint says , &quot; and not merely exc@@ essed . &quot;
+This emer@@ ges from a long-term study by an international team of researchers , including a number of employees of the German Institute for N@@ ut@@ ri@@ tional Research ( DI@@ f@@ E ) in Pots@@ dam .
+Pot@@ enti@@ ally , a large number of cameras could solve the problem ...
+Ast@@ onom@@ ers concluded at the time that there had to be a sub@@ surface sea at least at the south p@@ ole .
+The tot was cr@@ ying so hard that she v@@ om@@ ited , she added .
+At a press conference , Colo@@ m said that his decision is according to the independence of judiciary and executive powers , taking into account that a trial court had already ordered the ex@@ tradition .
+However , they managed and retained the profit , even though lower than before the crisis .
+A Mis@@ si@@ ssi@@ pp@@ i newspaper , deep in the South of the United States , wrote an edi@@ torial : once inside the voting cabin we know well enough to whom the American patri@@ ot will give his vote .
+With the du@@ el of San@@ tos Lag@@ una and Monter@@ rey in the final , in addition two different styles marked by their technici@@ ans &apos; face , who find each other with a contrast marked by results .
+However , Berlin subsequently abstained from voting .
+At the end of last April , the municipal council of Gi@@ o@@ ia Tau@@ ro was dis@@ solved but already in 1991 , and always for pre@@ sum@@ ed conditioning between organised crime and local administration , local politicians had been relie@@ ved from duties of administration of the municipality .
+I should be careful with my kne@@ e which was injured but I walk fine now .
+Super@@ glu@@ e to be able to walk on walls
+At the moment , P@@ ac@@ l@@ í@@ k &apos;s strongest dis@@ agreement with Pel@@ ta is based on the latter &apos;s connection to Roman Ber@@ b@@ r , President of Pil@@ sen &apos;s regional football association . Ber@@ ber is a man of controversial reputation , who is , behind the scenes , known as powerful lob@@ by@@ ist , capable of influ@@ encing the votes of general meeting deleg@@ ates .
+I think that in Europe , and even in the USA , a great understanding for the German position prev@@ ails .
+The victims were mainly elderly women ten@@ ding the p@@ lots of relatives .
+A 2@@ 9-@@ year-old wanted to fulfil a dream and r@@ ented a Ford Mu@@ st@@ ang .
+Cor@@ ner@@ back Dar@@ rel@@ le Re@@ vis inter@@ cep@@ ted an er@@ rant throw and returned it 32 yards for a tou@@ ch@@ down .
+I &apos;m a patri@@ o@@ tic husband , you &apos;re my patri@@ o@@ tic wife , let &apos;s do our civi@@ c duty and create life !
+&quot; This thing is evol@@ ving so quickly that I don &apos;t know what &apos;s going to happen next , &quot; said Daniel J. O@@ ates , the police chief in A@@ ur@@ ora , just east of Den@@ ver .
+Or does Germany still find leadership roles difficult ?
+A combination of gen@@ res
+After all , the balance sheet total for U@@ BS in 2007 was more than five times the economic output of Switzerland ( see chart ) .
+The people who have trav@@ elled there will then be hou@@ sed in emergency shel@@ ters in Wies@@ baden , according to a statement made by the city of Wies@@ baden on Tuesday evening .
+This is the photogra@@ ph &apos;s aim when collecting an original i@@ con@@ ography of fla@@ men@@ co , taken from different perspectives .
+Although this does not guarantee that it was the mur@@ derer , it places him it in the murder scene .
+At the main P@@ enn@@ sy@@ lv@@ ania State University camp@@ us , Latin American History Professor Mat@@ the@@ w Rest@@ all , and his colleague Am@@ ara Sol@@ ari , an Associ@@ ate Art History and Anth@@ rop@@ ology Professor , have te@@ amed up to give a course , called simply &quot; The end of the world . &quot;
+But the greatest advantage of the music cell phones for many people is the price .
+&quot; He has never had any interest in K@@ all@@ stadt . &quot;
+Pet@@ ron@@ ella W@@ y@@ att : I was bul@@ lied out of Oxford for being a T@@ ory
+&quot; For the first time it was said that the countries who want are to cooperate , while those who are not willing can stand off . &quot;
+The female employee suffered from shock .
+Now that we are 7 thousand million human beings on the planet , demographic development will involve a doub@@ ling of demand for electricity by 2050 , unless a huge proportion of the world &apos;s population is deprived of a vital element .
+&quot; At first you think of working for po@@ sterity , then you realize you only work for the prosperity , and at certain point you just sh@@ oot a film more , &quot; says Gar@@ cia after more 30 years of career .
+The decision was taken unanimously by the 11 judges , while a majority of seven was sufficient to force the dis@@ b@@ anding , Mr. K@@ ili@@ ç indicated , adding that 37 of the party &apos;s representatives , including its president , Ah@@ met Tür@@ k , and the dep@@ uty , Ay@@ sel Tu@@ glu@@ k , have been ban@@ ished from political life for the next five years .
+&quot; I think that applicants are influenced strongly by external assessments of any potential employer , &quot; she says .
+Pla@@ ying live he only needs a guitar and ban@@ jo .
+Par@@ agu@@ ay , which was suspended by UN@@ AS@@ UR in 2011 after the dis@@ miss@@ al of former President Fern@@ ando Lu@@ go , was not involved in the meeting .
+The ne@@ bul@@ a , 1,@@ 400 light years away , consists of partic@@ les of dust that are ten to one hundred times smaller than standard house dust .
+They recognised the size and shape of stone needed to collapse the platform without much training .
+The police announced in a statement that ten@@ ants of the building on Mari@@ en@@ felder Alle@@ e noticed smoke on the sta@@ ir@@ case and cont@@ acted the fire bri@@ ga@@ de .
+`@@ R@@ un ! &apos; R@@ un and man the seats in the rear part of the tent .
+For part of Dep@@ fa &apos;s loan portfolio - approximately 50 billion Euros - H@@ yp@@ o Real Estate annually requires short-term capital for re@@ financing .
+The king of k@@ ung@@ -@@ f@@ u in Montreal
+&quot; That is something quite special for me , I am Rap@@ id off@@ spring &quot; , Sch@@ ra@@ m@@ mel said .
+&quot; The intervention by organized crime during the entire election process and especially yesterday is alarming , not just for Mich@@ o@@ ac@@ an but for the entire country , &quot; Lu@@ is@@ a Maria Cal@@ der@@ on said in a radio interview a day after Sunday &apos;s vote .
+But now I can play computer games with shooting and it is not a problem for me .
+&quot; More than 70 percent of adults in Bur@@ k@@ ina Fas@@ o cannot read , &quot; pointed out the disadvantage of written education Die Standard daily .
+The chairman of the Central Council of Muslims , A@@ im@@ an Maz@@ ye@@ k , expressed the fear on Thursday that religious conflict could also be brought to Germany .
+I felt the way homo@@ sexu@@ als must have felt before the liberal legislation of the Six@@ ties .
+W@@ om@@ an seriously injured by attempted hand@@ bag rob@@ ber@@ y
+The reduction of 5@@ 5@@ ,000 jobs which has been taking place for three years is not yet completed .
+It must react inst@@ inc@@ tively and instantly because this technology corresponds to the most vulnerable and inner@@ -@@ most layer of the safety shi@@ eld , a layer in which a crash is currently considered un@@ avoid@@ able .
+And she added : &quot; No virtual operator is likely to appear in the T-@@ Mobile network by the end of the year .
+He does not hesitate to reply that he would never accept a request from an unknown person .
+Climate : How France tam@@ pers with its promises of finance .
+Comp@@ ulsory education ?
+It is always fat@@ al .
+He emphasi@@ zed that the proposal included those consumer protection pass@@ ages that he had supported , too .
+The ex President Alber@@ to Fu@@ j@@ im@@ ori was hosp@@ itali@@ zed Tuesday in a public hospital in order to be evaluated for the loss of mus@@ cle strength that occurs in the legs , informed his family doctor .
+The classic PC that defined the computer standards of the period , called IBM 5@@ 150 , came to the market in 1981 .
+The comparison to war is ap@@ posite .
+Bi@@ den does the best of the three on honest@@ y , while Clinton &apos;s strength is leadership .
+And , in a match , it &apos;s easier .
+The 7@@ 6-@@ year-old film@@ maker had f@@ led the United States before his sentence had been passed for &quot; un@@ lawful sexual relations &quot; with a 13@@ -@@ year-old minor .
+The re@@ located pa@@ vili@@ on
+However the issue of liability for accidents and the security of drivers &apos; personal data must be conclu@@ sively clarified .
+Pakist@@ ani authorities on Saturday zer@@ o@@ ed in on the alleged master@@ mind of a plot to send five Northern Vir@@ g@@ inia men to Afghanistan to kill U.S. troops , saying they hope the case could help un@@ ra@@ vel an extensive network of terrorist recru@@ it@@ ers who sc@@ our the Internet for ra@@ dic@@ alized young men .
+Bay@@ ona suggests that the answer to the question that gives the title of this piece is complex , because the contest rules lack a global view of Col@@ l@@ ser@@ ola : &quot; 16 cross con@@ tests have been called -@@ he sa@@ y@@ s-@@ on se@@ a@@ - mountain sense , but there is no lon@@ git@@ u@@ din@@ al reading , to see and understand the area as a whole . &quot;
+&quot; This shows how much this is worth to us , &quot; says W@@ ent@@ z@@ ler .
+Republi@@ can leaders justified their policy by the need to combat electoral fraud .
+&quot; We have done everything to contact them , &quot; said States Department Spo@@ kes@@ man Phili@@ p Cro@@ wle@@ y .
+The ice cream university was created by the manufacturer of ice cream makers in 2003 to ensure that the ice cream from all its makers met exac@@ ting Italian standards .
+The Barcelona store includes a space with a pione@@ ering pilot program at a world-@@ wide level that is in charge with solving the possible problems of a computer science equipment of HP still with guarantee .
+Their situation wasn &apos;t helped by a recent B@@ BC Two documentary , W@@ onder@@ land : Young , B@@ right and on the Right , about student politics , which portra@@ yed T@@ ories as od@@ d@@ balls and neo-@@ Naz@@ is .
+After several months of discussions , the parties agreed in late 2009 to put the company up for sale .
+Agreement on the issues , and elec@@ tability are also c@@ ited .
+For almost ten years the cho@@ ir has been practi@@ sing songs in this foreign , &apos; soft &apos; language , and now and then they bring them back to where they originally came from : the South of Africa .
+&quot; This is a traditional position that all governments have reiter@@ ated .
+The squ@@ at@@ ters , who had inv@@ aded 11 of the 13 floors of the building , the rest are inhabit@@ ed@@ - took all the wir@@ ing and part of the water , painted the walls and left resi@@ du@@ es of all kinds , especially alcoholi@@ c be@@ verage cans .
+Ry@@ ch@@ y@@ t@@ á@@ ř does not care who his wife sle@@ ep@@ s with
+Ad@@ ministr@@ ators at P@@ enn State have been charged with per@@ jury for alle@@ ge@@ dly covering up reports that a reti@@ red football coach was sex@@ ually ass@@ aul@@ ting boys .
+&quot; The message is coming from a number which is not reflecting but it &apos;s ti@@ tled &apos; death &apos; , &quot; he told journalists after Mr Mugabe &apos;s speech .
+Solar@@ world came in 5@@ 5th place among the 100 best employers in Germany in a study by the Great Place to Work Institute .
+As such , the experts debated , for instance , when the sau@@ ri@@ ans split into the three most important lines of development : the car@@ ni@@ vor@@ ous ther@@ o@@ po@@ ds , which later included Ty@@ ran@@ no@@ sau@@ rus re@@ x , the Vel@@ o@@ ci@@ rap@@ tor and birds , the four-@@ leg@@ ged sau@@ ro@@ po@@ ds known as the &quot; long nec@@ ks &quot; and their relatives , and the plant@@ -@@ eating Or@@ ni@@ th@@ isch@@ i@@ ae ( bir@@ d-@@ hi@@ pped sau@@ ri@@ ans ) , which included , for instance , the Tri@@ cer@@ at@@ ops and Ste@@ go@@ sau@@ rus species .
+Sol@@ di@@ ers in this book have be@@ eh@@ i@@ ves fall on them ; one has Christmas in Egypt under the py@@ rami@@ ds ; ts@@ et@@ se f@@ lies are an in@@ trac@@ table problem .
+The injury was caused by a reck@@ less tackle from H@@ é@@ c@@ tor Mor@@ eno in the 15th minute after the 20-@@ year-old Sha@@ w had bur@@ st into the PS@@ V area .
+It distributed it in An@@ long Ven@@ g in June as a supplement to the Education Ministry &apos;s high school history text@@ book , which contains fewer than four pages about the K@@ h@@ mer Rou@@ ge .
+Time passes , but poverty perpet@@ u@@ ates from generation to generation in one of the har@@ dest jobs in the world : the one done by human mul@@ es in the Ka@@ wa@@ h I@@ j@@ en volcan@@ o .
+However , often they cause no pain or any other symptoms , thus remaining un@@ detected .
+&quot; They are being sp@@ at@@ tered with mu@@ d and attempts are being made to compromise them , &quot; alleged Mr. Putin .
+But since the Great Rec@@ ession , Fed leaders have acknowledged that there &apos;s an un@@ written third mandate : financial stability .
+The district &apos;s adverti@@ sement called for female applicants 18 to 22 years old , with a good figure and &quot; the five fac@@ ial features in proper order . &quot;
+Its decision-making process is &quot; more art than science , &quot; said Z@@ ach@@ ary Kar@@ ab@@ ell , head of global strategy for weal@@ th-@@ management firm En@@ v@@ est@@ net Inc .
+The other under@@ gradu@@ ates gi@@ gg@@ led .
+Mor@@ eno suggests that students &apos; pe@@ ers , such as residential advis@@ ors , could monitor the site and intervene to help a student who posts one too many boo@@ zy status updates .
+Charles Sch@@ wa@@ b strategi@@ sts believe the hi@@ ke in rates will cause yiel@@ ds between lon@@ ger@@ - and shor@@ ter-@@ dated bonds to move closer together , flat@@ tening the cur@@ ve .
+&quot; We will review all these paths , &#91; which &#93; are not exclusive , and the treaty with Nicar@@ agua will require a conversation with Nicar@@ agua &quot; he emphasised .
+The other part will be paid according to the number of games played this year .
+At 18 : 05 the remains of B@@ acio Cor@@ t@@ és ( cre@@ m@@ ated ) , a citizen of Sal@@ ti@@ llo arrived to be given by the fun@@ er@@ al home to members of the Mexican Air Force , led by Major James Mart@@ ine@@ z , on the es@@ plan@@ ade of the training school , where he was already expected by his family , including his daughter Am@@ anda and his wife Crist@@ ina , her mother , bro@@ thers and other relatives , students and teachers .
+Key events :
+Perhaps it sounds parado@@ x@@ ical , after all , we have three mobile networks here and over 100 % coverage .
+The 4@@ 8-@@ year-old human rights lawyer and Chairman of the Egyptian Organisation for Human Rights ( E@@ O@@ HR ) defended the Muslim Bro@@ ther@@ hood , when impris@@ oned or in court under Mu@@ bar@@ ak .
+The staff will drop to about 3@@ 20 from over 400 .
+But Putin &apos;s call upon the Kie@@ v government to negotiate with the pro-@@ Russia insur@@ gen@@ ts as equ@@ als correspon@@ ded with the apparent strategy he has followed since the violence began five months ago : Help the separ@@ ati@@ sts take territory and force the Ukrainian government to grant the newly proc@@ laimed No@@ vor@@ o@@ ssi@@ ya region virtual independence to ali@@ gn with Russia instead of the West .
+&quot; Rol@@ l up , don &apos;t be cheap , get your art@@ work &quot;
+Fi@@ xed income also has been vol@@ atile as the market anticip@@ ates a rate hi@@ ke , and the pattern is somewhat similar to what equi@@ ties experience .
+Par@@ du@@ bi@@ ce and H@@ ra@@ de@@ c Kr@@ alo@@ ve region
+The Tok@@ yo@@ -based Fu@@ j@@ it@@ su cor@@ poration s@@ ells itself as the third largest IT provider in the world .
+Otherwise , a project for one of the gates can crash into the program and definition with the project of the architect of the next gate .
+Some@@ thing big was coming .
+This z@@ est for like already be@@ ams out of Mr L@@ i , he said flat@@ tering the host .
+He said : &quot; We want to make religion more relevant to people in a post-@@ Ch@@ risten@@ dom society .
+Meanwhile , the Belgian , Dutch and Luxembourg governments partially nation@@ alized the European financial con@@ gl@@ om@@ er@@ ate For@@ tis .
+My time finally came in the late &apos; 9@@ 0s .
+Sy@@ lv@@ ain Sim@@ ard let it be known that the four companies comp@@ r@@ sing the con@@ sortium ( B@@ PR , Des@@ sau , Group S@@ N and A@@ x@@ or ) are &quot; well known to Que@@ bec Liberal Party . &quot;
+On top of that , they must accept that the SI@@ M card in their telephone is not registered under their name , and thus they cannot use all of its features like the regular customers of the mobile operators can . &quot;
+The latest wave of violence between Israel and the Gaza strip , as always , has spark@@ ed a lot of reaction .
+One possible pri@@ z@@ e-@@ winner in the pol@@ l may be the last year &apos;s EU regulation according to which inf@@ lat@@ able bal@@ lo@@ ons must be sold with a warning that children under 8 years of age may not infl@@ ate them without par@@ ental supervision .
+&quot; I have worked at a hospital where positive as@@ best@@ os claims have been made , &quot; he says , &quot; But I can &apos;t prove it in my case .
+While B@@ rei@@ vi@@ k may have acted alone , he was far from alone in cy@@ ber@@ space : he had spent much of the time leading up to his attack at his computer , chat@@ ting with some of the millions of nation@@ alists who support right-@@ wing groups on soci@@ al-@@ networking sites .
+The authors of the study estimate the added value in the field of driver assistance systems and highly automated driving functions in Germany will be around € 8.@@ 4 billion for 20@@ 25 .
+&quot; Person@@ ally , I think they are aver@@ age-@@ looking , &quot; Mr. T@@ ang said , dis@@ mis@@ sively .
+After a first attempt by the guest cap@@ tain K@@ auff@@ mann who narro@@ w@@ ly missed the goal from a far shot , I@@ ll@@ ha@@ e@@ usern went on to take a slight lead and in turn F@@ onder@@ f@@ lick from af@@ ar , then with Hir@@ n from high , Rom@@ ain with the tip of his foot or again Die@@ bold came to ti@@ ck@@ le the Dan@@ ne@@ mar@@ ie defence .
+The &quot; grand fin@@ ale &quot; of the Som@@ er@@ set House exhibition is Mar@@ ie-@@ Ch@@ ant@@ al Mil@@ ler &apos;s wedding dress from her marriage to Paul of Greece in 1995 .
+&quot; Do you plan to wear the dirty so@@ cks tomorrow ? &quot;
+Over 19 % of o@@ bes@@ e children had fried chips for dinner the day before the research connected to the educational event called O@@ be@@ sity is No Ac@@ ci@@ dent .
+Tru@@ mp &apos;s favor@@ ability ratings have turned 180 degrees .
+Mr Kir@@ chner , who continued to handle economic policy even after his wife succeeded him as president , was in the hab@@ it of drawing up budgets which under@@ estimated tax revenues , economic growth and inflation .
+The CD@@ U is taking bes@@ mir@@ ched walls as the pretext to crimin@@ alise the protest , said Jan@@ ine Wis@@ s@@ ler ( Left Party ) .
+It one of the most widespread formats and in addition to it , the absolute majority of devices can also handle music in W@@ MA format .
+This is great advice for shooting on dry land , but it is even more important under@@ water because of the di@@ m lighting conditions .
+&quot; With the help of subsidies we have built a research and training center , we have enhanced our presentation at international fairs , won major awards in local exhibitions , &quot; says Ž@@ ď@@ á@@ r@@ sk@@ ý .
+In a series , SP@@ I@@ EG@@ EL ON@@ LIN@@ E presents a selection of responses to the question , `@@ What do you consider to be true without being able to prove it ? &apos;
+92 % of new infec@@ tions are through sex , 6 % via the bloo@@ d@@ stream and 2 % per@@ in@@ at@@ al .
+Then there &apos;s the question of methodology .
+At the fifth year , compared to the sle@@ eve gast@@ rec@@ tom@@ y group , the b@@ yp@@ ass surgery group had lost more weight ( 18.@@ 7 v@@ s 14.@@ 2 kg ) , achieved larger drop@@ s in BM@@ I ( 7.@@ 4 v@@ s 5.@@ 1 ) and in h@@ emo@@ glob@@ in A@@ 1@@ c ( 3.1 percent v@@ s 2.1 percent ) and were more likely to have complete di@@ abetes re@@ mission ( 4@@ 6.@@ 9 percent v@@ s 16.@@ 7 percent ) .
+The work being done by experts from three institutions , the Czech Academy of Sciences , V@@ Š@@ CH@@ T Prague , and the University of Heidelberg , is opening up the way to deal with the r@@ the virus &apos; resistance .
+At the time he considered the city to be a de@@ generate hot@@ bed of vice .
+Although it seems a pit@@ tance for such an in@@ human effort , it is three times what he would earn in the field .
+&quot; We followed the spirit of the times and this need for new means of writing , not@@ with@@ standing the rise of e-mail , &quot; explains Maria Seb@@ reg@@ on@@ di .
+&quot; Cer@@ tain parameters &quot; were mentioned in the black@@ -@@ red government program .
+Dra@@ w
+There were signs she &apos;d been be@@ aten , and rig@@ or mor@@ tis had already set in .
+The indoor temperature is very pleasant .
+The 15th week for the employment of the han@@ dic@@ apped starts today .
+Bre@@ it got her interest in fashion from her mother , when she was still in the cra@@ dle .
+In addition , the project is also nom@@ inated for the Dutch National W@@ ood Award 2012 .
+Pi@@ ff@@ l : &quot; Even I was skep@@ tical at first .
+It is located 700 light years away in the Aqu@@ ari@@ us con@@ stell@@ ation .
+There are at least 15 versions of the balanced budget amendment in the House alone , and another hand@@ ful that would &quot; control federal spending . &quot;
+The social foundation is moving down from the mountain into the town centre .
+Lu@@ ci@@ ano war@@ ns against letting the spirit of the age lead you ast@@ ray .
+In August , defe@@ ated presidential candidate M@@ eh@@ di Kar@@ rou@@ bi said some prote@@ sters de@@ tained after the election had been tor@@ tured to death in prison and others had been rap@@ ed .
+The oldest of his five children , 30 years old , also works carrying sul@@ ph@@ ur .
+It is essential and legitimate to look for the best fan of energies for our country , but it would be irresponsible to allow emo@@ tion , dog@@ mas and parti@@ san manoeu@@ v@@ res to domin@@ ate the debate , which is so decisive for the economic , social and financial situation of our country .
+Kno@@ w@@ les said P@@ ren@@ ti@@ ss , who had a ho@@ und dog named Ligh@@ tn@@ ing , had been dating Lam@@ b for about three years .
+As@@ best@@ os has been , and in many cases still is , embedded in the homes we live in , the offices we work in , the schools we are educated in , and the stores we shop in .
+&quot; It was always in the back of our minds that the Müll@@ ers would fit into this practice well , &quot; says Dr Ur@@ sel Fel@@ steh@@ au@@ sen and lau@@ gh@@ s .
+In@@ jured people at pun@@ ch-@@ up in fast food restaurant
+Last week , leading fund manager Ham@@ ish Dou@@ glass , the founder of Mag@@ ell@@ an Financial Group , told a business lunch in Mel@@ bour@@ ne that Met@@ cash could &quot; highly , probably disappear within a decade .
+&quot; I always thought that Wu@@ ff@@ li and O@@ sp@@ el were a dream team , &quot; says the banking research , Hans Gei@@ ger .
+The conflict between the union and the airline had led to a number of strikes over the past months .
+It &apos;s hard to see them breaking a leg to help the Sel@@ f@@ ie Bri@@ ts , whose energy might be better spent preventing Scotland leaving the UK - something they don &apos;t want either because most have similar separ@@ ati@@ st tenden@@ cies .
+Plu@@ rali@@ sm and Pra@@ g@@ mati@@ sm in a Sec@@ ular@@ ist State .
+&quot; The ev@@ acu@@ ation of this morning was dis@@ gu@@ sting and shows that deep inside Blo@@ om@@ berg is more interested in preserving the financial interests of American workers , &quot; added the spo@@ kes@@ man of the movement , who accused the may@@ or of &quot; dis@@ respect for the freedom of expression . &quot;
+It asks employees how happy they are with their work and job environment and looks at the general working conditions .
+Cou@@ p@@ on checked by self-@@ service machine instead of driver
+&quot; Be@@ er p@@ ong &quot; is the name of the bizarre spectac@@ le ; the winner gets 500 Euros win bonus plus plane tickets to Las Vegas for the beer p@@ ong world champ@@ ionship in January .
+Moreover , it should be noted that the country yiel@@ ded to the principles of the United Nations Commission on International Trade , that is the rules set for cross-border in@@ solven@@ cy cases , ensuring fairness for deb@@ tors and credi@@ tors .
+Although the motion on Europe de@@ votes a paragraph to the importance of &quot; Fran@@ co-@@ German friendship , &quot; Angel@@ a Merkel did not mention France .
+Es@@ me N@@ uss@@ baum lower@@ ed her head .
+One of them could be Ge@@ ely , which aims to acquire Vol@@ vo , but the option of the Dutch sports car manufacturer Sk@@ yp@@ er , which is funded by the Russian group Conver@@ g , is gaining momentum .
+Indeed , she has had fron@@ t@@ line experience of her own .
+So what specifically does a &quot; normal &quot; foreign policy ent@@ ail , from a German perspective ?
+Hungarian officials also closed two of seven border cross@@ ings with Serbia on Tuesday morning after deplo@@ ying a train car covered with ra@@ z@@ or wire to close one of them .
+Most often , Cze@@ chs spent their holiday at home , which resulted in great number of cot@@ tages and summer houses , a hab@@ it that survi@@ ves until now .
+In Vienna , there is word that the Syri@@ ans were afraid of some kind of fishing ex@@ pedition and worry that the IA@@ EA is being sent out by the USA as a van@@ guard to sp@@ y out military facilities .
+Because the pol@@ l has been taken regularly since 1995 , it tracks changes in attitude across the region .
+It may also clu@@ stered people in groups of conversation .
+Our advice on how to choose
+When it was in the dres@@ sing room he had an oxy@@ gen mask on .
+T@@ ens of thousands gathered on Friday evening at the T@@ ah@@ ri@@ r Square in C@@ airo , in un@@ familiar unity , and ple@@ dged to bring down the charter before it has even come into effect .
+Pf@@ c. Eli@@ z@@ abe@@ th Ly@@ man was 25 years old and 11 weeks pregn@@ ant the night she says she was rap@@ ed by a fellow soldi@@ er .
+The Secretary Di@@ on@@ isi@@ o Per@@ ez Jac@@ ome gives details of the crash where the Inter@@ ior Minister , Francisco B@@ lake , and seven others died .
+The choice of Berlin will result in a rise of the price of electricity , an increased energy dependence ag@@ gra@@ vated by increased rec@@ ourse to imported gas , in particular from Russia , a jump in carbon dioxide emissions due to the construction of gas and of coal centres .
+Long before he led the revi@@ val of Apple , Jobs pres@@ ci@@ ently fo@@ res@@ a@@ w the ways in which so many industry leaders would st@@ um@@ ble in their vision , and lose control of their market share .
+His lifestyle , however , has remained hum@@ ble ,
+In the means of investigation it is emphasi@@ zed that , for the moment , no data has been found related to the persons arrested in Catal@@ onia regarding the attack of Bom@@ bay , although the author of this attack , &quot; Las@@ k@@ ar e Tai@@ ba &quot; , has been one of the receiving groups of the pas@@ sports rob@@ bed in Spain and soon fal@@ si@@ fied in Thailand .
+Bas@@ ketball glo@@ betro@@ tter H@@ ec@@ tor &quot; H@@ eti@@ n &quot; Re@@ yes was involved in the sport for over 60 years and , thanks to it , trav@@ elled the world .
+They are currently working on a fashion boutique in Gel@@ sen@@ kir@@ chen .
+Around the supplies stand located in the me@@ ado@@ ws of the castle garden , people from Salz@@ we@@ del , but also guests from near and far , made themselves at home .
+The announcement came from the company as a reaction to the harsh criticism of their salary policies .
+The response has been under@@ whel@@ ming , family planning officials say .
+&quot; I wor@@ e lots of h@@ ats in bas@@ ketball throughout my life , including several at the same time , like when I was president of the BS@@ N , general manager and feder@@ ative president of the National Team during the &apos; 9@@ 0s , &quot; rec@@ alled Re@@ yes during Pri@@ mer@@ a Hor@@ a &apos;s visit to his home in Bay@@ am@@ ón , where he lives with Isa@@ bel , his lo@@ yal wife for over 50 years .
+The small house is in a class@@ y neighbourhood with ten@@ ded front gardens . Large , expensive cars are par@@ ked in the dri@@ ve@@ ways .
+In fact , it comes from a single meeting of 12 people conven@@ ed to develop a multi-@@ criteria decision analysis ( M@@ C@@ DA ) model to syn@@ the@@ si@@ se their opinions on the har@@ ms associated with different nic@@ ot@@ ine-@@ containing products ; the results of the meeting were sum@@ mar@@ ised in a research paper .
+Every day B@@ BC News - on TV , on radio and online - brings you the latest stories from across the globe ... but what we want to hear are the issues that matter to you .
+Together with The Ta@@ p Ta@@ p band , we tend to jo@@ ke about it , saying that we might be the only band on earth that could draw enough positive energy to hold off or aver@@ t the end of the world completely .
+When the ground is wet , water diff@@ uses inside the covering and it &apos;s hard to get out , this causing a sof@@ tening of all layers of the p@@ av@@ ement and , therefore , the formation of po@@ th@@ ol@@ es .
+However , Ha@@ š@@ ek &apos;s era sees football back in quar@@ rel@@ s between both association cham@@ bers , unable to agree on a common candidate .
+&quot; The quality of these particular customers is pretty strong . &quot;
+`@@ It could be dark matter existing very close to Earth that may be responsible for the an@@ om@@ aly , &apos; he w@@ rites .
+What is private offline is private online
+This will provide high-speed internet access to 400@@ ,000 people and will provide work for the German firm for 18 months .
+Since this is the layer that will be in contact with the wheels of the vehicle , it must have a better mechanical strength than the asp@@ halt covering and provide road fri@@ ction .
+With each of the nine teams
+On the agenda is the fate of un@@ conventional measures of support for countries of the Eurozone in the market col@@ li@@ mat@@ or ( see above ) .
+Another re@@ publi@@ can who was in favour , John Mc@@ C@@ ain , has not defined his position at this moment .
+Among the most vulnerable to new infec@@ tions are teen@@ agers .
+This was said by Mi@@ los@@ la@@ v Kal@@ a , vic@@ e-@@ president of the Supreme Audi@@ t Office ( N@@ K@@ U ) in an interview for Aktu@@ al@@ ne@@ .@@ c@@ z.
+I think it &apos;s partly because we have nine disc@@ s and we can play more than 120 songs and everyone likes different songs , so it &apos;s difficult to choose which songs to play every night .
+I saw some things there and came out stronger .
+They had agreed to a ran@@ som , &apos; the agent said .
+No confirmation could be obtained from A@@ I@@ G .
+Stars who lost their mo@@ jo
+&quot; I want to avoid all kinds of representative non@@ sense , as at the previous general meeting , &quot; says the owner of Vi@@ kt@@ orie Pl@@ ze@@ ň , who is a candidate for the first time ; and in his statements he chie@@ fly stood against Pel@@ ta .
+Ty@@ mo@@ sh@@ en@@ ko claims the verdi@@ ct is a political re@@ ven@@ ge of the regime ; in the West , the trial has also e@@ vo@@ ked suspicion of being bi@@ ased .
+Since you &apos;re starting un@@ i at the height of Bak@@ e-@@ O@@ ff man@@ ia , kno@@ cking on people &apos;s doors to introduce yourself with a plate of brow@@ ni@@ es seems margin@@ ally less wei@@ rd , less 1950@@ s &quot; Welcome to the neighbourhood , I bak@@ ed you something , now s@@ mile as I ask you personal questions . &quot;
+Even though I had tim@@ ed the ch@@ ore to coinci@@ de with the late afternoon l@@ ull at my local branch of J@@ P Morgan Ch@@ ase , a qu@@ eu@@ e of 20 or so people was already waiting in line .
+Conver@@ sely a British soldi@@ er reali@@ zes that he will most likely die , and that no one will notice or care .
+S@@ re@@ e@@ kan@@ th Chal@@ as@@ ani , a resear@@ cher at the Sal@@ k Institute in La J@@ ol@@ la , California , told the Gu@@ ardi@@ an that the procedure could one day replace deep@@ -@@ brain stim@@ ulation , an inv@@ a@@ sive procedure that delivers electrical pul@@ ses into people &apos;s bra@@ ins to treat symptoms of Park@@ inson &apos;s disease .
+Appar@@ ently not enough security guards had been booked with the security company .
+I &apos;m not someone who likes to talk in front of other people , mind you , let alone a class of 40 .
+But the Texas native br@@ us@@ hed aside her concern .
+However , despite what he says , Morgan Fre@@ em@@ an is proud of the new film .
+The prime minister does not exclude calling for an election before the end of the year
+And he explains why he is p@@ aci@@ f@@ ist ; what lies behind his criticism of society ; his political heart and soul ; and also how his thoughts and ideas have been shaped and moul@@ ded - not only by music ( he was an opera lo@@ ver who became a soul and rock musi@@ cian ) but by his prison experience , too .
+Sal@@ e@@ h al@@ -S@@ om@@ ali was one of two Arab men thought to have been killed when a pair of missi@@ les t@@ ore into their car Tuesday near the town of Mi@@ ran Sha@@ h in North Wa@@ zi@@ rist@@ an province , according to U.S. sources and Pakist@@ ani officials in the region .
+New cars that fall under the emissions class &quot; Euro 6 &quot; will receive a higher nit@@ ric o@@ xide value .
+Minister of Education , Youth , and Sports , Jose@@ f Do@@ be@@ š , would like to force the split parties inside the strongest sports association in the country to reach an agreement .
+M. Monti , known for his competence and for his independence when he was European Commissioner ( 199@@ 4-@@ 2004 ) , represents a &quot; change of e@@ po@@ ch &quot; for Italy after 17 years of &quot; ber@@ lus@@ con@@ ism , &quot; the &quot; professor &quot; symboli@@ sing &quot; the challenge of seri@@ ousness &quot; and &quot; another Italy , &quot; according to the lea@@ der@@ writers .
+Here are some recent pol@@ l numbers that suggest that the real estate mo@@ gu@@ l isn &apos;t just a passing phase :
+He alle@@ ge@@ dly attempted to mani@@ p@@ ulate the current tender for the settlement of res@@ titu@@ tion claims , so that the land offered was awarded to a particular candidate .
+The impact and dimensions of Stuttgart 21 cannot be over@@ estimated .
+Go@@ ali@@ e Pet@@ r Ce@@ ch prevented a potential own goal from T@@ omas Si@@ vo@@ k in the 9th minute with a spli@@ t-@@ second refle@@ x .
+When Jus@@ tin B@@ ie@@ ber drinks coffee people go@@ ggle through the window .
+Its in@@ ventions include , for example , the cash point , pay card , financial s@@ wap , bar code , and flo@@ ppy disc .
+Another communication dated Jan@@ au@@ ry 2008 and signed by amb@@ assador Wil@@ k@@ ins , war@@ ns Washington about the increasingly negative image of the United States conve@@ yed by drama series broadcast@@ s by C@@ BC .
+&quot; I don &apos;t know if they answer me , I only upload them &quot; he adds .
+On Monday , the micro@@ blog site Twitter introduced changes in the presentation of its platform , to allow its users , in particular , to observe the activity of those whom they are monitoring , which makes its service res@@ emble that of Facebook .
+Whether the current smo@@ g in the city state will have any influence on the Grand Prix in Singapore is as yet unclear .
+A t@@ we@@ et on Sha@@ w &apos;s account read : &quot; Thank you everyone for your messages , words can &apos;t describe how gut@@ ted I am , my road to recovery starts now , I will come back stronger . &quot;
+The defense has said it plans to have Mann@@ ing ple@@ ad guilty to less@@ er off@@ enses and fight other charges as being too extreme .
+Of the seven lo@@ pho@@ scop@@ ists working in the branch of CT@@ I , this week it was the turn of &quot; availability &apos; for Ele@@ az@@ ar Gonz@@ al@@ ez , a man of Puerto Te@@ j@@ ada , who had spent 21 years working in the area of judicial investigation .
+Kon@@ stan@@ tin V@@ assi@@ l@@ je@@ v e@@ quali@@ sed for the away team in the 5@@ 7th minute .
+The engineers could not get a half-@@ decent sound out of it .
+In the letter dated from 2003 , L@@ ili@@ ane Bet@@ ten@@ court added , according to the lawyer : &quot; could you explain to my daughter that I wrote to Mr. Ban@@ ier once or twice a day for fifteen years . &quot;
+In the opera category , the nom@@ ine@@ es are Berg &apos;s &quot; Lul@@ u &quot; from the Orchestra of the Royal Opera House ; Ad@@ olf H@@ asse &apos;s &quot; Marc Antonio e Cle@@ op@@ at@@ ra &quot; from Ar@@ s Ly@@ ri@@ ca Hou@@ ston ; Ka@@ i@@ ja Sa@@ ari@@ ah@@ o &apos;s &quot; L &apos;@@ Am@@ our de Lo@@ in &quot; from Deutsch@@ es Symp@@ hon@@ ie-@@ Or@@ chester Berlin ; Ro@@ dion Sh@@ che@@ dr@@ in &apos;s &quot; The En@@ chan@@ ted W@@ anderer &quot; from the Orchestra and Ch@@ or@@ us of the Mari@@ in@@ sky Theatre ; and Ar@@ thur Sul@@ li@@ van &apos;s &quot; I@@ van@@ ho@@ e &quot; from the B@@ BC National Orchestra of Wales .
+It should read : &quot; Here lies the honest citizen J@@ R E@@ wing . &quot;
+Being ci@@ gar@@ -@@ shaped , it is introduced inside the 1-@@ met@@ re wide pipeline , and it is pushed along by the gas .
+He was once a foot@@ b@@ aller but now T@@ im Wi@@ ese , ex-@@ national go@@ ali@@ e for Germany who also played for Bremen and Hoff@@ en@@ heim , is a w@@ rest@@ ler .
+Char@@ ity CM@@ T UK said that mis@@ diagnosis is a common problem among people with CM@@ T because so little is known about the condition .
+Even if the ceas@@ e@@ fire agreed on November 21st holds , this week &apos;s fighting has strengthened the ha@@ w@@ ks on both sides .
+&quot; The walls are difficult because they are not suitable surfaces to get a print , but in this case we could get the print of the whole hand and identify the off@@ ender , who had participated in several rob@@ ber@@ ies &quot; he said .
+So , the KM@@ T tends to avoid par@@ ading its ties to the government in Beijing .
+According to him he wanted to put on 30 kg of mus@@ cle mass in the past two years .
+And for a good cause .
+At Japanese schools , the b@@ ent@@ os aren &apos;t just lunch .
+He was certainly a designer , dre@@ am@@ er and self-@@ identified hi@@ pp@@ ie , but he was also a me@@ ticul@@ ous organiz@@ er and f@@ low-@@ chart t@@ weaker - a man who believed that many business exec@@ u@@ tives suffered from &quot; a disease of thinking that a really great idea is 90 percent of the work ... &#91; but &#93; there &apos;s a tremendous amount of cra@@ fts@@ manship between a great idea and a great product . &quot;
+&quot; Overall , we found that there has been working on , we believe it is necessary to develop a long term program that re@@ defines the vocation and the economic course of the state , it is important to de@@ ton@@ ate all the material and human potential resource that Sin@@ alo@@ a has , &quot; he said .
+The Müller couple liked the idea of running their own practice in A@@ sen@@ dorf in the future .
+F@@ ed@@ E@@ x earnings mixed , lo@@ wers fiscal 20@@ 16 out@@ look
+Unfortunately , the Czech regulatory organs have been to@@ s@@ sing the whole case back and forth like a hot pot@@ ato .
+UN@@ AM asp@@ halt would avoid po@@ th@@ ol@@ es
+A ticket for any type of city transportation costs 6 sh@@ ek@@ els , and you can ride for 1.5 hours with transfers .
+The choice depends entirely on the manner of use and demands of the future owner .
+The departure of French combat troops was completed on 20 November .
+Most of those ahead of me , I was to learn later from Star@@ r , my &quot; licensed personal ban@@ ker &quot; , were lining up for the same reason as me .
+If opposition members enter parliament , it is because they have been appointed , not elected .
+Salvador Bar@@ ra@@ za Ru@@ bi@@ o , president of the Association of Ret@@ ail@@ ers of the Zone Dor@@ ada , remembered that in different occasions they have den@@ ounced that the image of the dest@@ iny should be taken care of and to change the bad perc@@ ep@@ tions that the tourists might find with new activities or routes .
+Autom@@ ated and net@@ worked driving will increase traffic safety and ensure fewer traffic j@@ ams , said D@@ ob@@ rin@@ dt .
+Ta@@ wa Hal@@ la@@ e looked like many other car@@ ni@@ vor@@ ous din@@ o@@ sau@@ rs : The animal , standing two metres t@@ all and with a length of 1.@@ 50 metres on two strong h@@ ind legs , had a lon@@ g@@ ish sk@@ ull with sharp , cur@@ ved teeth , short arms with si@@ ck@@ le-@@ shaped cla@@ ws and a long tail .
+Canadi@@ ans are living half dead , according to a report of the Royal Society of Canada
+Martin was still a teen@@ ager when she had him in 19@@ 31 during her marriage to lawyer Ben H@@ ag@@ man .
+An extra flight that was to take , among others , the V@@ ice Presidents D@@ ali@@ bor Ku@@ č@@ era and Ra@@ j@@ ch@@ l to Pod@@ gor@@ ica did not leave Prague in the morning due to a technical failure . An alternative was sought for in order to transport part of the executive board to the scene of the bar@@ ra@@ ged re@@ match .
+&quot; Terror of the Gali@@ cian woman ( ins@@ cription ) . &quot;
+&quot; They were brought up with no concept of doing business . &quot;
+Cri@@ tics as@@ sa@@ iled the project as promoting both terrorism and traffic ti@@ e-@@ ups .
+Its leaders had war@@ ned prior to the verdi@@ ct that the representatives would leave Parliament rather than take their seats as representatives with no affili@@ ation .
+This , it must be said , still has huge shortcomings , offering no explanation for gra@@ vity ( o@@ ops ! ) or dark matter , which forms approximately 80 % of the matter in the Uni@@ verse ( re-@@ o@@ ops ! ) .
+The pressure turns a tur@@ b@@ ine which in its turn fuels a generator .
+This amounts to a short@@ fall of 14@@ 0@@ ,000 homes .
+While he was last seen sm@@ ash@@ ing a rac@@ quet after cra@@ mp fo@@ iled a potential US Open up@@ set of Richard Gas@@ quet , K@@ ok@@ kin@@ akis has been defended staun@@ ch@@ ly by He@@ aly .
+Sha@@ res in G@@ len@@ core rose 5 % after the mining giant said it had raised $ 2.@@ 5@@ b@@ n through a share placement as part of its deb@@ t-@@ cutting strategy .
+The debate continued on the newspaper &apos;s website .
+It is still a priority that anyone wanting to claim asylum can &quot; of course &quot; do so .
+&quot; But it is possible . &quot;
+He told Radio@@ ž@@ ur@@ n@@ á@@ l that he was hal@@ ting the campaign for Christmas and would re@@ start it in the New Year .
+But in something of a tw@@ ist , &quot; those who combine their online activ@@ ism with offline activ@@ ism are more reasonable , more democratic and less violent than those who just remain behind the computer screen . &quot;
+`@@ Not everything was fun to look at today , &apos; Mar@@ cell Jan@@ sen later admitted .
+The deal was dis@@ closed in a joint statement issued after Secretary of State H@@ ill@@ ary Ro@@ d@@ ham Clinton met with Belar@@ us@@ an Foreign Minister Ser@@ ge@@ i Mar@@ ty@@ no@@ v on the si@@ delines of a security summit here .
+The close supporters of C@@ aro@@ d demand the president something more than putting his position at the disposal of the milit@@ ancy , a gest@@ ure that is not worth when Pu@@ ig@@ cer@@ c@@ ó@@ s controls the most important organ between con@@ gres@@ ses .
+Ari@@ zona , USA , is home to the Large Bin@@ o@@ cular Tel@@ es@@ cope .
+The drama series on C@@ BS about the E@@ wing cl@@ an and other characters in their or@@ bit ai@@ red from April 1978 to May 1991 .
+&quot; It is a fundamental issue we cannot exist without , &quot; Pel@@ ta claims .
+&quot; Japan , like the rest of the world has its eyes ri@@ v@@ eted on Europe and the exchanges will ch@@ ase one another in a corri@@ dor of narrow variations as investors will not have proof that the situation has stabili@@ sed , &quot; states Mit@@ sus@@ hi@@ ge Ak@@ ino , fund manager at I@@ chi@@ yo@@ sh@@ i Investment Management .
+He said some kids are drinking san@@ i@@ tiz@@ er inten@@ tionally , while some do it to im@@ press their friends or on a soci@@ al-@@ media dare .
+According to the weather service Me@@ te@@ om@@ edi@@ a , Sax@@ on Switzerland was put on red alert - the highest alarm level .
+They is psycho@@ tic , she was , after all , ques@@ tioned more than once .
+Su@@ cc@@ ess is there .
+The office of minister Ale@@ š Ř@@ eb@@ í@@ č@@ ek hopes that it will discou@@ rage drivers from be@@ having danger@@ ously behind the wheel .
+The England head coach , Tre@@ vor Bay@@ li@@ ss , pra@@ ised his attitude even when he was not performing as well as he can and that does not surprise me ; he is a team man above all else .
+This characteristic also connects many with the billi@@ on@@ aire who wants to become US president .
+B@@ ie@@ ber himself , whose new album is due out in November , is not interested in all those zer@@ os .
+The representation should be the shopping window of football .
+Two hundred to 400 thousand , which I still do .
+The last man , who lived with her , decla@@ res his grie@@ f for feeling guilty .
+Architec@@ tural design company , Arch@@ .@@ Design , whose studios produced a number of important buildings in Br@@ no , have included the space for their corporate tiny kin@@ der@@ garten even in the first drawings of the Av@@ ri@@ o@@ point building .
+The fact that the influence of former Securit@@ ate members is still very big in Romania was proven after the announcement of the Nobel prize for Her@@ ta Müller by an interview , in which a former Securit@@ ate head from Tim@@ iso@@ ara spoke in dero@@ g@@ atory terms of the prize winner .
+Sa@@ vers could see gains as well through higher yiel@@ ds at the , though experts differ on how quickly that will take hold .
+&quot; However , many people told me I mu@@ st@@ n &apos;t give up , otherwise others would follow . &quot;
+One of our main goals is the Champ@@ ions League : we qualified for the last 16 in the right way .
+Even though most data show the economy growing soli@@ dly , the recent tur@@ mo@@ il in global financial markets could make al@@ read@@ y-@@ cau@@ tious Fed officials sk@@ it@@ tish about adding to the vol@@ atility by raising their bench@@ mark federal funds rate - even by no more than a mere quarter of a percentage point .
+The two far-@@ Right parties that captured almost 30 percent of the vote , the Freedom Party and the Alliance for the Future of Austria , have campa@@ ig@@ ned on an veh@@ e@@ ment@@ ly anti-@@ immigration ticket and some of their slo@@ gan@@ s were deemed xen@@ opho@@ bic by critics .
+Pe@@ ek and Ri@@ ck@@ ard , who live in Red@@ ding , are in town for the AK@@ C / Eu@@ kan@@ u@@ ba National Championship in Long Beach this weekend , where they planned to show Tra@@ ce .
+According to this a &quot; g@@ able roof with an off-@@ centre ri@@ dge and roof over@@ hang &quot; will be constructed .
+I think you have something a lot less life threatening .
+This ground@@ -@@ breaking legislation will give workers the same legal options for union organizing discrimination as for other forms of discrimination - stopping anti-@@ union forces in their tracks
+The one recorded in the second quarter , for the Japanese the Fis@@ cal Year begins in March 2012 - represents also the fastest rhyth@@ m of growth from January to March 2010 .
+Sit@@ ting side by side on the tri@@ b@@ une of the audi@@ t@@ orium of the Sta@@ de de France , Geor@@ ges Le@@ ek@@ ens and Eden H@@ az@@ ard made peace .
+Certainly , most of you have been told talked in your sleep .
+The couple also have two grand@@ children and enjoy travelling .
+The highlights : man@@ ne@@ qu@@ ins which look al@@ arm@@ ingly human thanks to video projec@@ tion .
+There is much at stake , as South Australia and Western Australia account for almost 30 per cent of Met@@ cash &apos;s IG@@ A store foot@@ print and generate higher profit mar@@ gins than Met@@ cash &apos;s IG@@ A network in the eastern states .
+In France , the start is more modest ; 400@@ .000 cont@@ ac@@ tless Visa card are in use .
+Lud@@ wi@@ k Sob@@ ole@@ wski , President of the Warsaw Stock Exchange confirmed the bid that has been taken by the Polish , in spite of the fact that the Czech had previously excluded the Warsaw Stock Exchange from the group of potential owners of the Prague shares .
+Mul@@ tin@@ ation@@ als with lots of debt will fare worse , as a rising dollar makes their products more expensive in the global market space and their debt more expensive the finance .
+Ko@@ val@@ e@@ v gained the victory by sc@@ oring the only goal of the sho@@ ot@@ out .
+Ear@@ lier this week Sal@@ man vo@@ wed to reveal what caused the c@@ ran@@ e to t@@ opp@@ le into a courtyard of the Grand Mo@@ s@@ que , where hundreds of thousands of Muslims have conver@@ ged ahead of the ha@@ j@@ j pil@@ gri@@ ma@@ ge later this month .
+Moreover , he says his motivation is to continue the work he started with Ha@@ š@@ ek .
+It is part of a rev@@ itali@@ sation project , which also includes an underground car park , a super@@ market , a post office and a small number of adjacent apartment buildings and terra@@ ced houses , with a total of 50 d@@ well@@ ings .
+The premi@@ er of the A@@ mu@@ la-@@ Open@@ -@@ Air@@ s was more than a success in terms of the number of visitors .
+But how to find them ?
+The last six@@ teen of the Champ@@ ions League ( first leg 16 / 17 + 23 / 24 February / second leg 9 / 10 + 16 / 17 March ) will be drawn in Ny@@ on on 18 December .
+That list included the F@@ 35 Joint Stri@@ ke Fi@@ ghter , a planned new bom@@ ber , the ne@@ x@@ t-@@ generation bal@@ li@@ stic sub@@ marine , the new litt@@ oral combat ship and the new ground combat vehicle the Army and Mar@@ ines need to replace the hum@@ ve@@ e .
+Due to the s@@ lum@@ p in the housing market , young adults of necessity live longer in &quot; Hotel M@@ ama &quot; .
+There will have to be talks in the coming days with Brussels and other countries , &quot; I@@ vi@@ ca D@@ ac@@ ic said in Prague .
+Consu@@ mption alone was a sp@@ ur to the economy in the early part of the year , whilst investments were down .
+The owner of the club says that the inv@@ aders of the farm made ​ ​ her an unfair competition , since they were selling drinks for three Euros , while in the club worth 10 .
+In collaboration with the Soci@@ é@@ té internationale d &apos;@@ u@@ ro@@ log@@ ie &#91; SI@@ U &#93; , Mo@@ v@@ ember has created a tool that makes it possible to evaluate the pro@@ s and cons of the PS@@ A test .
+The only candidate who be@@ ats him ?
+The only exception was the period from 1962 to 1972 , when we had the opportunity to travel to Yugoslavia . Nevertheless , the Yugosla@@ vian regime turned West , which caused significant limitations to trips to Yugoslavia for Czech tourists .
+The 20-@@ year old tells us there are &quot; three in the eight to twel@@ ves , six in the twel@@ ves to 15 &quot; .
+When the United States occupied Japan after World War II , General Dou@@ glas Mac@@ Ar@@ thur and his ai@@ des encouraged the country to adopt a constitution designed to assure that H@@ ide@@ ki To@@ jo &apos;s milit@@ ari@@ zed auto@@ cracy would be replaced with democracy .
+They describe how the El@@ ys@@ ée explained its strategy to the Americans , going so far as to give them advice on the treatment of their own &quot; ho@@ stage &quot; in Iran crises ( a small group of tri@@ p@@ pers ) .
+The report details the gains , which every country would achieve through this international programme .
+And then the words &quot; you pay &quot; are in a pool of blood .
+Fre@@ em@@ an said that he had asked n@@ in@@ et@@ y-@@ one-@@ year-old Mand@@ ela if he could play him in E@@ ast@@ wood &apos;s film .
+Indeed , the best way to understand what El@@ li@@ son , Le@@ wis and the co@@ spon@@ sors of their legislation are proposing is as a re@@ connection with a very American idea .
+&quot; The conflict has increasingly become an economic competition , &quot; Mr. Eng@@ l@@ und w@@ rites , &quot; a war between factories . &quot;
+In comparison , 26@@ 0@@ ,000 units were completed in this year in Germany .
+In the north of the country , at an ele@@ vation of 16@@ 00-@@ 20@@ 40 m , there is a famous ski resort called Her@@ mon , which f@@ ills up with tourists in winter months .
+&quot; Only my name is thr@@ ust into the fore@@ front , &quot; says Lu@@ k@@ á@@ š Py@@ t@@ lou@@ n mo@@ dest@@ ly today .
+&quot; Throughout the years in business , I &apos;d always ask : &quot; Why do you do things ? &quot; and the answers you inv@@ ari@@ ably get are : &quot; O@@ h , that &apos;s just the way it &apos;s done . &quot; &quot;
+While l@@ ur@@ king in the other are the bo@@ sons , a n@@ asty band of an@@ arch@@ ists who respect nothing - at all events , not this principle , which means that they can indeed be found in the same place at the same time .
+Pro@@ b@@ ably there is not a more appropriate place in the world than Paris to present a fashion award , and probably there is not a living designer as exquisite as Val@@ entino .
+In the fight against Ukrainian government troops , pro-@@ Russian separ@@ ati@@ sts say that they have once again shot down a war@@ plane and two military helicop@@ ters .
+B@@ ous@@ quet be@@ sted the Cro@@ at , Du@@ je Dra@@ gan@@ ja ( 20.@@ 70 ) and the Russian , Ser@@ ge@@ y Fe@@ si@@ ko@@ v ( 20.@@ 84 ) , but he did not manage to reduce the world record time ( 20.@@ 30 ) as he had envisaged .
+Jus@@ tin B@@ ie@@ ber in the capital city : on a B@@ ie@@ ber ex@@ pedition in Berlin
+Within the construction project at the J@@ ed@@ li@@ ck@@ a Institute , a separate building is planned , which we can move into with this project .
+The body of a young woman was found on Tuesday evening in Ro@@ cken@@ hausen near Kais@@ er@@ slau@@ tern the public prosec@@ utor &apos;s office and police reported on Wednesday .
+Thus , proposes a reform of the stat@@ utes that allows celeb@@ rating the con@@ gres@@ ses through deleg@@ ates chosen by suff@@ rage .
+Companies in the District , Mar@@ y@@ land and Vir@@ g@@ inia collec@@ tively for@@ ked over $ 10 billion in state and local property taxes last year , up from $ 9.@@ 6 billion in 2012 - year-@@ over-@@ year growth of 4.@@ 2 percent .
+Now everyone knows that the labor movement did not dimin@@ ish the strength of the nation but enlarged it .
+&quot; I was terrible for me to hear some of them say that at this point , they don &apos;t even want to identify themselves with Czech football . &quot;
+According to the German Federal Statisti@@ cal Office , however , in the last year fewer than half of all asylum seekers have lived as ten@@ ants .
+Watson led the company until 195@@ 2 .
+Traff@@ i@@ ckers move towards Germany over minor border cross@@ ings .
+By raising the living standards of millions , labor mi@@ ra@@ cul@@ ously created a market for industry and lifted the whole nation to und@@ re@@ amed of levels of production .
+&quot; But the idea is that it is not the price which is imp@@ port@@ ant , but people &apos;s skills &quot; stated M. La@@ porte .
+Jo@@ an Ri@@ vers has been un@@ conscious since her arrival three days ago at a New York City hospital , but her daughter expressed hope today that the 8@@ 1-@@ year-old com@@ edi@@ an will recover from her illness .
+Eth@@ ics experts said the unusual arrangement between Mr. En@@ sign and Mr. Hamp@@ ton , who were close friends before the affair , appeared at odds with the so-called revol@@ ving door lob@@ b@@ ying ban .
+He said Lam@@ b made the f@@ ateful 9@@ 11 call some@@ time after that .
+However , the judge &apos;s ruling means that for the time being doctors can continue to perform legal abor@@ tions while seeking such privileges .
+I@@ r re@@ sts on the bottom of the sea , at an average depth of 200 metres .
+According to the English press , the government to endorse all outstanding loans in the bank Bra@@ d@@ ford and B@@ ing@@ ley , including more than 41 billion ( 7@@ 5.@@ 5 billion U.S. ) in real estate loans .
+However the refugees in Germany are not being systematically asked about their qualifications so as to be able to help them get started , criticised Clau@@ dia Walter , project manager for integration and training in the Ber@@ tel@@ sm@@ ann Foundation .
+We don &apos;t look like orph@@ ans , we &apos;re not little children , was how he re@@ acted to the question of whether the O@@ DS was not ham@@ pered by the presence of the party chairman in the parliament and in the Czech Republic during the political negotiations regarding the budget .
+Exper@@ ts believe sh@@ op@@ pers could be holding off making purchases ahead of the event , which takes place on the last Friday in November .
+The CT@@ M@@ O trademark office then also dis@@ missed the Mun@@ ich@@ -based company &apos;s appeal .
+A few hundred Belar@@ usi@@ ans gathered on Sunday evening at the closing of pol@@ ling stations in the central square of Min@@ sk to protest against the frau@@ dul@@ ent elections .
+R@@ enz@@ i hopes , not least , to be able to thus qu@@ ieten the left-@@ wing party basis which is always stir@@ ring against him , for Mo@@ gh@@ er@@ ini is considered to be one of their group - albeit one of the more moderate .
+As for Richard J@@ auber@@ t ( C@@ G@@ T ) , he described it as &quot; an acceptable compromise &quot; .
+The def@@ end@@ ants were not able to provide accurate documentation for the earlier years .
+&quot; A great amount of work was done in those two years , and I don &apos;t want to throw it all away . &quot;
+Hamburg -
+In large amounts , it increases the risks of developing colo@@ -@@ rec@@ tal cancer .
+We have already written many times on Mobil@@ .@@ cz about the fact that Czech operators are among the most expensive in Europe .
+On the opposition side , the outline of the Northern Plan was received with scep@@ ticism .
+He also promised to solve the Boh@@ em@@ ians case ; improve relations with both U@@ EF@@ A and F@@ IFA ; bring more money to football ; and continue the work of the previous President , I@@ van Ha@@ š@@ ek .
+The report was critical of White House officials , law@@ makers and the former Att@@ or@@ ney General Alber@@ to Gonz@@ ales .
+The 19 participants of a desert ex@@ pedition were already on their way to C@@ airo , it said .
+Con@@ gres@@ sman Ol@@ ver@@ a ad@@ mits that after 12 years outside the presidential palace of Los Pin@@ os , there is much expec@@ tation within the party about En@@ ri@@ que P@@ ena Nie@@ to .
+The vast majority will move with Fischer and the internal medicine ward that still continues to exist to Sch@@ on@@ gau .
+Re@@ plying in the afternoon , the Minister of Natural Res@@ ources N@@ ath@@ ali@@ e Nor@@ man@@ de@@ au , denied vigor@@ ously any col@@ lu@@ sion in connection with this contract .
+H@@ ep@@ ati@@ tis : when shall we turn to a doctor ?
+Many areas in the country have no doctor – A@@ sen@@ dorf by contrast is fortunate : on 1 October Dr Frank Müller is taking over the Fel@@ steh@@ au@@ sen practice .
+Karl März and Ad@@ olf Ri@@ ed led the club as range officers during its tough early years . The main objective then was to find a club pu@@ b and set up a shooting company .
+The bo@@ ard@@ room is now con@@ tem@@ pl@@ ating the possibility of working together .
+The artist was in Florida at the time of the incident , the Associ@@ ated Press news agency reported .
+He has also played in only 65 of Ar@@ senal &apos;s 15@@ 7 le@@ ague games during the last five seasons .
+Pi@@ ra@@ e@@ us had won their six most recent premi@@ ere class home games , including against prominent clubs such as Manchester United , At@@ le@@ tico Madrid and Ju@@ vent@@ us Turin .
+We &apos;re trying to implement a game project .
+H@@ a said Z@@ ico had sold up to 6@@ ,000 to wholes@@ ale out@@ lets and was awaiting new stock .
+The head of the bank then plans to announce changes following the investigation at the end of January .
+He was legally acqu@@ it@@ ted of this charge in May .
+Comm@@ o@@ dities trading may be reduced or stopped completely .
+&quot; They want to go out but they have in mind the price situation , &quot; he men@@ tions .
+Exper@@ ts fear that Albert Ein@@ stein &apos;s general theory of rel@@ ativity may not be entirely correct .
+B &amp; Q bo@@ ss says Eastern European tra@@ des@@ men working cheap is behind trend
+The ro@@ cket was designed as a two-@@ stage ro@@ cket , with a total length of 5@@ 10 cm and a launch weight of 3@@ 2.5 kg .
+FC Ein@@ tra@@ cht Bam@@ berg moved into the last 16 with their victory against district le@@ ague no . 1 FC Ober@@ ha@@ id ( 3 : 1 ) and at home against regional le@@ ague no . 1 FC Schwein@@ fur@@ t 05 ( 3 : 2 ) .
+And on the other hand , where do we still lag behind more advanced countries ?
+The executive committee has refused to enter into the necessary dis@@ course .
+Perhaps the most unusual pool design awaits bath@@ ers in Län@@ gen@@ feld . The Aqu@@ a D@@ ome in Ö@@ tz@@ tal looks like a U@@ F@@ O has just land@@ ed in the Alps .
+The new unity does not create unanimity
+Assi@@ sts of J@@ á@@ g@@ r and Vor@@ á@@ č@@ ek Hel@@ ped Phi@@ la@@ del@@ phi@@ a &apos;s Vic@@ tory
+On Wednesday , Que@@ bec F@@ lood Fo@@ rec@@ ast Centre issued flood war@@ nings in respect of several rivers , in particular Mas@@ kin@@ ong@@ é , As@@ som@@ ption , Ou@@ are@@ au , L &apos;@@ Ach@@ ig@@ an , B@@ atis@@ can and Lou@@ p .
+Many smo@@ kers in Australia remain de@@ fi@@ ant .
+The architect Ad@@ olf Kris@@ chan@@ itz has now renovated the pa@@ vili@@ on , which has been named the &quot; 2@@ 1@@ er Haus &quot; and will be used as a contemporary art museum .
+The word was not included in the previous Constitution .
+Due to Mario P@@ av@@ eli@@ c &apos;s recent pel@@ vis injury , Sch@@ ra@@ m@@ mel moved from playing left back to right back , where he also did a very good job .
+They were able to partially limit the damage .
+The verdi@@ ct of the judges was unanimous .
+U@@ BS was a major player in foreign exchange and stocks .
+It &apos;s part of the essential voc@@ abul@@ ary of Japanese girls and means `@@ cu@@ te , &apos; `@@ sweet . &apos; 
+&quot; What happens if my personal data are used against me , if it is discovered what I do ? &quot; , ask some of the users worrying about the inform@@ ation-@@ monopoly of Google .
+It remained one of the seven state symbols even following the creation of the independent Czech Republic .
+Of course these lessons are very different from those at a proper school .
+In the following year , the P@@ TA &apos;s first chairman , Kaz@@ im@@ ier@@ z Zar@@ ank@@ ie@@ wi@@ cz ( 19@@ 02 - 195@@ 9 ) was appointed Dep@@ uty Chairman for the International A@@ stron@@ au@@ tics Federation .
+The teaching staff demand the immediate termination of the criminal prosec@@ ution .
+The benefits of weight loss surgery for mil@@ dly o@@ bes@@ e people with type 2 di@@ abetes can last at least five years , according to a new study .
+A ro@@ cky foot@@ path leads up to the somewhat 600 year old o@@ ak tree .
+G@@ ates , who was to return to Washington late Friday , met in the morning with Iraqi Prime Minister N@@ our@@ i al-@@ M@@ ali@@ ki before flying to Iraq &apos;s o@@ il-@@ rich Kurdish region for meetings with troops in Kir@@ ku@@ k and Kurdish officials in Ir@@ bi@@ l .
+&quot; We often had to find a material that was good , cheap and met with the approval of the monument authority , &quot; says Kris@@ chan@@ itz , pointing to the rough flo@@ oring in the bas@@ ement .
+West@@ L@@ B would contribute to the deal a `@@ blo@@ c of expertise &apos; with sustained earning power , it says .
+&quot; This is where this paper is critical , because it says this surgery is safe in that lower BM@@ I group , &quot; with no increased risk of death or ren@@ al disease , she said .
+In smaller cities the prices are lower in absolute terms , but they have a higher impact on the local economy .
+But in any case , the balance is not there , ob@@ serves Jean-@@ Franç@@ ois For@@ get , general secre@@ tary of U@@ F@@ AP .
+We need to let the computer world into our physical world , make it more tangible .
+Since this does not yet exist , construction plans are still subject to vari@@ ation .
+L@@ ack of Sco@@ ts title race bo@@ res Dutch - de Bo@@ er
+It is in@@ expensive and sa@@ ves time .
+That &apos;s important because they will be less likely than other airlines to cancel or delay air@@ plane orders when fuel prices rise , Di@@ hor@@ a said .
+They will have to give up their current relationship with Iran ; they will have to give up their relationship to the ( Shi@@ -@@ ite movement ) He@@ z@@ bollah ; they will have to give up the ongoing support they provide to the terrorism of the ( Shi@@ -@@ ite movement ) Hamas , ( the terrorist network ) Al-@@ Q@@ ae@@ da and the ji@@ had ( hol@@ y war ) in Iraq , &quot; the prime minister specified .
+It &apos;s an immense body , that occup@@ ies 70 % of the planet &apos;s surface and now the big , international energy companies are discovering it .
+That &apos;s not to say there won &apos;t be effects , however .
+However , there are tou@@ gher go@@ ssi@@ ps , women who enjoy frequent go@@ ssi@@ ping and des@@ p@@ ise everyone . They are , especially within a female work team , very dangerous for their surroundings .
+With all the risks .
+Fast food restaurants increase it with time , but very little . On average their ordinary employees in New York earn 8.@@ 90 dollars / hour .
+In@@ ci@@ dentally , it is the most unusual sea in the world , located in the lowest point of the planet - 4@@ 17 m below sea level .
+Super@@ Camp@@ s confirmed that the text was provided from Cam@@ eron &apos;s staff , but had no further immediate comment .
+En@@ try is free of charge , and contributions are strictly not allowed .
+P@@ rec@@ isely why our brain plays such tri@@ cks on us , is still pu@@ zz@@ ling to scientists .
+Deutsche Bahn has come up with a crisis plan to prevent train cancell@@ ations in the winter .
+The dis@@ closure of the U.S. Emb@@ assy mem@@ o , which didn &apos;t occur until late evening Moscow time , is sure to sti@@ r disp@@ le@@ as@@ ure within the Russian government , although to the extent that Lu@@ zh@@ ko@@ v can be bl@@ amed for Moscow &apos;s fail@@ ings , it might be an opportunity for the Kre@@ m@@ lin to argue that it is solving the problem .
+There was no answer to this for a long time .
+Such was the work of the person who identified the body of Al@@ fon@@ so Can@@ o
+The US air strike ordered by the German Kun@@ du@@ z comm@@ ander Col@@ on@@ el Kl@@ ein , up to 142 people were killed of injured , according to the NATO inquiry report .
+On the other hand , the administration does not often ease their life .
+He told Czech Radio earlier that he had inten@@ tionally selected sing@@ ers with young , representative voices that were striking and popular for the solo vari@@ ants .
+Poland may soon have a nation@@ alistic government of the right , Spain one of the left .
+One more check of more than 200 thousand p@@ es@@ os in favour of Lor@@ ena Guad@@ al@@ up@@ e Cam@@ ach@@ o Pal@@ a@@ zu@@ el@@ os was issued by the City council .
+She can even feel his presence , at least for some moments .
+The NC@@ U@@ A chairman , Deb@@ bie Mat@@ z , welcomed the respon@@ si@@ veness of the two banks .
+Between January and October 2012 1@@ 18@@ ,@@ 800 Ukrainian tourists visited the Holy Land , which is 51 % more than a similar figure in 2010 , before the removal of the visa regime on February 9 , 2011 .
+According to the dan@@ cer &quot; we do not pre@@ tend to tell her whole life , but to collect her spirit .
+So far , the state has been paying around 500 thousand cro@@ wns a year on all general vacc@@ inations for children .
+The amount greatly excee@@ ds the price of admission to other Gau@@ di &apos;s buildings in the city .
+Deutsche Bahn has also been forced to have the ax@@ les of ICE trains checked significantly more frequently for many years , after an ICE train &apos;s ax@@ le broke in Cologne &apos;s main station .
+The weather , especially hum@@ idity and temperature variations are also a very important factor to consider , especially water , he said , because it greatly affects the performance of the asp@@ halt .
+Other applications could be within the a@@ erospace industry .
+Five hundred American journalists have been asked by P@@ EW Research Centre what they think of the state of their profession and mental control as regards to the future .
+Sur@@ v@@ ey that remo@@ ves absurd regulations
+This has done little to calm fears in An@@ long Ven@@ g .
+Pol@@ ls and analysis conducted immediately after the elections , which established the far Right as the country &apos;s strongest political blo@@ c , indicate that the change was brought about by predomin@@ ately young voters who are concerned about their future in the European Union .
+And , among the possibilities that are con@@ tem@@ pl@@ ated , the one of leaving a monetary zone of little serious countries cannot be excluded .
+Toler@@ ated , sometimes assisted , by local insur@@ gen@@ ts , the latter will no longer be so when West@@ ern@@ ers become more scar@@ ce .
+&quot; The first hi@@ ke from the Fed since the global financial crisis will inevitably be interpreted by some as sign@@ aling the end of the era of &apos; cheap money , &apos; &quot; Ju@@ lian Jes@@ so@@ p , chief global econom@@ ist at Capital Econom@@ ics , said in a note to clients .


### PR DESCRIPTION
This PR will resolve #279 .

I added both raw text and tokenized+subword splitted (according to latest bpe) versions.

The calibration data is distilled from the newstest training data used for training the GNMT model, excluding newstest2014, as this is considered the "validation set" .