### PR TITLE
Chrome trace

### DIFF
--- a/loadgen/logging.h
+++ b/loadgen/logging.h
@@ -62,6 +62,110 @@ const T& ArgValueTransform(const T& value) {
   return value;
 }
 
+/// \brief outputs a trace that can be uploaded to chrome://tracing for
+/// visualization.
+/// \detail Trace event format definition:
+/// https://docs.google.com/document/d/1CvAClvFfyA5R-PhYUmn5OOQtYMH4h6I0nSsKchNAySU/edit?usp=sharing
+class ChromeTracer {
+ public:
+  ChromeTracer(std::ostream* trace_out, PerfClock::time_point origin);
+  ~ChromeTracer();
+
+  template <typename... Args>
+  void AddCompleteEvent(const std::string& name, uint64_t pid, uint64_t tid,
+                        PerfClock::time_point start, PerfClock::time_point end,
+                        const Args... args) {
+    *out_ << "{\"name\":\"" << name << "\","
+          << "\"ph\":\"X\","
+          << "\"pid\":" << pid << ","
+          << "\"tid\":" << tid << ","
+          << "\"ts\":" << Micros(start - origin_).count() << ","
+          << "\"dur\":" << Micros(end - start).count() << ","
+          << "\"args\":{";
+    AddArgs(args...);
+    *out_ << "}},\n";
+  }
+
+  template <typename... Args>
+  void AddAsyncBeginEvent(const std::string& name, uint64_t id,
+                          PerfClock::time_point time, const Args... args) {
+    *out_ << "{\"name\":\"" << name << "\","
+          << "\"cat\":\"default\","
+          << "\"ph\":\"b\","
+          << "\"id\":" << id << ","
+          << "\"ts\":" << Micros(time - origin_).count() << ","
+          << "\"args\":{";
+    AddArgs(args...);
+    *out_ << "}},\n";
+  }
+
+  template <typename... Args>
+  void AddAsyncInstantEvent(const std::string& name, uint64_t id,
+                            PerfClock::time_point time, const Args... args) {
+    *out_ << "{\"name\":\"" << name << "\","
+          << "\"cat\":\"default\","
+          << "\"ph\":\"n\","
+          << "\"id\":" << id << ","
+          << "\"ts\":" << Micros(time - origin_).count() << ","
+          << "\"args\":{";
+    AddArgs(args...);
+    *out_ << "}},\n";
+  }
+
+  template <typename... Args>
+  void AddAsyncEndEvent(const std::string& name, uint64_t id,
+                        PerfClock::time_point time) {
+    *out_ << "{\"name\":\"" << name << "\","
+          << "\"cat\":\"default\","
+          << "\"ph\":\"e\", "
+          << "\"id\":" << id << ","
+          << "\"ts\":" << Micros(time - origin_).count() << "},\n";
+  }
+
+  template <typename... Args>
+  void AddCounterEvent(const std::string& name, uint64_t pid,
+                       PerfClock::time_point time, const Args... args) {
+    *out_ << "{\"name\":\"" << name << "\","
+          << "\"ph\": \"C\","
+          << "\"pid\":" << pid << ","
+          << "\"ts\":" << Micros(time - origin_).count() << ","
+          << "\"args\":{ ";
+    AddArgs(args...);
+    *out_ << "}},\n";
+  }
+
+  void Flush() { out_->flush(); }
+
+ private:
+  using Micros = std::chrono::duration<double, std::micro>;
+
+  void WriteTraceEventHeader();
+  void WriteTraceEventFooter();
+
+  void AddArgs() {}
+
+  template <typename T>
+  void AddArgs(const T& value_only) {
+    *out_ << ArgValueTransform(value_only);
+  }
+
+  template <typename T>
+  void AddArgs(const std::string& arg_name,
+               const T& arg_value) {
+    *out_ << "\"" << arg_name << "\":" << ArgValueTransform(arg_value);
+  }
+
+  template <typename T, typename... Args>
+  void AddArgs(const std::string& arg_name,
+               const T& arg_value, const Args... args) {
+    *out_ << "\"" << arg_name << "\":" << ArgValueTransform(arg_value) << ",";
+    AddArgs(args...);
+  }
+
+  std::ostream* out_;
+  PerfClock::time_point origin_;
+};
+
 /// \brief The proxy all logging lambdas ultimately use to write any log type.
 /// \details Passed as an argument to the log lambda on the
 /// recording thread to serialize the data captured by the lambda and
@@ -72,19 +176,15 @@ const T& ArgValueTransform(const T& value) {
 /// instances of a new LogOutput interface that the client may override.
 class AsyncLog {
  public:
-  AsyncLog();
-  ~AsyncLog();
-
   void SetLogFiles(std::ostream* summary, std::ostream* detail,
                    std::ostream* accuracy, bool copy_detail_to_stdout,
                    bool copy_summary_to_stdout,
                    PerfClock::time_point log_origin);
   void StartNewTrace(std::ostream* trace_out, PerfClock::time_point origin);
+  void StopTrace();
   void Flush();
 
-  void SetCurrentTracePidTidString(const std::string* pid_tid) {
-    current_pid_tid_ = pid_tid;
-  }
+  void SetCurrentPidTid(uint64_t pid, uint64_t tid);
 
   void LogAccuracy(uint64_t seq_id, const QuerySampleIndex qsl_idx,
                    const LogBinaryAsHexString& response);
@@ -113,16 +213,10 @@ class AsyncLog {
   void Trace(const std::string& trace_name, PerfClock::time_point start,
              PerfClock::time_point end, const Args... args) {
     std::unique_lock<std::mutex> lock(trace_mutex_);
-    if (!trace_out_) {
-      return;
+    if (tracer_) {
+      tracer_->AddCompleteEvent(trace_name, current_pid_, current_tid_, start,
+                                end, args...);
     }
-    *trace_out_ << "{ \"name\": \"" << trace_name << "\", "
-                << "\"ph\": \"X\", " << *current_pid_tid_
-                << "\"ts\": " << (start - trace_origin_).count() << ", "
-                << "\"dur\": " << (end - start).count() << ", "
-                << "\"args\": { ";
-    LogArgs(trace_out_, args...);
-    *trace_out_ << " }},\n";
   }
 
   template <typename... Args>
@@ -130,17 +224,9 @@ class AsyncLog {
                          PerfClock::time_point instant_time,
                          const Args... args) {
     std::unique_lock<std::mutex> lock(trace_mutex_);
-    if (!trace_out_) {
-      return;
+    if (tracer_) {
+      tracer_->AddAsyncInstantEvent(trace_name, id, instant_time, args...);
     }
-    *trace_out_ << "{\"name\": \"" << trace_name << "\", "
-                << "\"cat\": \"default\", "
-                << "\"ph\": \"n\", "
-                << "\"id\": " << id << ", " << *current_pid_tid_
-                << "\"ts\": " << (instant_time - trace_origin_).count() << ", "
-                << "\"args\": { ";
-    LogArgs(trace_out_, args...);
-    *trace_out_ << " }},\n";
   }
 
   void SetScopedTraceTimes(PerfClock::time_point start,
@@ -152,16 +238,10 @@ class AsyncLog {
   template <typename... Args>
   void ScopedTrace(const std::string& trace_name, const Args... args) {
     std::unique_lock<std::mutex> lock(trace_mutex_);
-    if (!trace_out_) {
-      return;
+    if (tracer_) {
+      tracer_->AddCompleteEvent(trace_name, current_pid_, current_tid_,
+                                scoped_start_, scoped_end_, args...);
     }
-    *trace_out_ << "{ \"name\": \"" << trace_name << "\", "
-                << "\"ph\": \"X\", " << *current_pid_tid_
-                << "\"ts\": " << (scoped_start_ - trace_origin_).count() << ", "
-                << "\"dur\": " << (scoped_end_ - scoped_start_).count() << ", "
-                << "\"args\": { ";
-    LogArgs(trace_out_, args...);
-    *trace_out_ << " }},\n";
   }
 
   template <typename... Args>
@@ -169,38 +249,19 @@ class AsyncLog {
                    PerfClock::time_point start, PerfClock::time_point end,
                    const Args... args) {
     std::unique_lock<std::mutex> lock(trace_mutex_);
-    if (!trace_out_) {
-      return;
+    if (tracer_) {
+      tracer_->AddAsyncBeginEvent(trace_name, id, start, args...);
+      tracer_->AddAsyncEndEvent(trace_name, id, end);
     }
-    *trace_out_ << "{\"name\": \"" << trace_name << "\", "
-                << "\"cat\": \"default\", "
-                << "\"ph\": \"b\", "
-                << "\"id\": " << id << ", " << *current_pid_tid_
-                << "\"ts\": " << (start - trace_origin_).count() << ", "
-                << "\"args\": { ";
-    LogArgs(trace_out_, args...);
-    *trace_out_ << " }},\n";
-
-    *trace_out_ << "{ \"name\": \"" << trace_name << "\", "
-                << "\"cat\": \"default\", "
-                << "\"ph\": \"e\", "
-                << "\"id\": " << id << ", " << *current_pid_tid_
-                << "\"ts\": " << (end - trace_origin_).count() << " },\n";
   }
 
   template <typename... Args>
   void TraceCounterEvent(const std::string& trace_name,
                          PerfClock::time_point time, const Args... args) {
     std::unique_lock<std::mutex> lock(trace_mutex_);
-    if (!trace_out_) {
-      return;
+    if (tracer_) {
+      tracer_->AddCounterEvent(trace_name, current_pid_, time, args...);
     }
-    *trace_out_ << "{\"name\": \"" << trace_name << "\", "
-                << "\"ph\": \"C\", " << *current_pid_tid_
-                << "\"ts\": " << (time - trace_origin_).count() << ", "
-                << "\"args\": { ";
-    LogArgs(trace_out_, args...);
-    *trace_out_ << " }},\n";
   }
 
   void RestartLatencyRecording(uint64_t first_sample_sequence_id, size_t latencies_to_reserve);
@@ -215,8 +276,6 @@ class AsyncLog {
  private:
   void WriteAccuracyHeaderLocked();
   void WriteAccuracyFooterLocked();
-  void WriteTraceEventHeaderLocked();
-  void WriteTraceEventFooterLocked();
 
   void LogArgs(std::ostream*) {}
 
@@ -253,10 +312,10 @@ class AsyncLog {
   bool warning_flagged_ = false;
 
   std::mutex trace_mutex_;
-  std::ostream* trace_out_ = nullptr;
-  PerfClock::time_point trace_origin_;
+  std::unique_ptr<ChromeTracer> tracer_;
 
-  const std::string* current_pid_tid_ = nullptr;
+  uint64_t current_pid_;
+  uint64_t current_tid_;
   PerfClock::time_point log_detail_time_;
   PerfClock::time_point scoped_start_;
   PerfClock::time_point scoped_end_;
@@ -532,7 +591,8 @@ void AsyncLog::LogDetail(const std::string& message, const Args... args) {
     detail_streams.pop_back();
   }
   for (auto os : detail_streams) {
-    *os << *current_pid_tid_
+    *os << "\"pid\": " << current_pid_ << ", "
+        << "\"tid\": " << current_tid_ << ", "
         << "\"ts\": " << (log_detail_time_ - log_origin_).count() << "ns : ";
     if (error_flagged_) {
       *os << "ERROR : ";


### PR DESCRIPTION
Fix trace event format:
- Async events do not need (pid, tid).
- Counter events only need tid.
- Times must be in microseconds.

Also:
Use system-level TID instead of C++ std::thread::id to enable correlation with other tools.