### PR TITLE
handle queries with empty results

### DIFF
--- a/v0.5/classification_and_detection/python/coco.py
+++ b/v0.5/classification_and_detection/python/coco.py
@@ -192,7 +192,7 @@ class PostProcessCoco:
                 # this is the index of the coco image
                 image_idx = int(detection[0])
                 if image_idx != self.content_ids[batch]:
-                    # this index thingies are error prone - extra check to make sure it is consistent
+                    # working with the coco index/id is error prone - extra check to make sure it is consistent
                     log.error("image_idx missmatch, lg={} / result={}".format(image_idx, self.content_ids[batch]))
                 # map the index to the coco image id
                 detection[0] = ds.image_ids[image_idx]

--- a/v0.5/classification_and_detection/python/main.py
+++ b/v0.5/classification_and_detection/python/main.py
@@ -57,7 +57,7 @@ SUPPORTED_DATASETS = {
          {"image_size": [1200, 1200, 3],"use_label_map": True}),
     "coco-1200-tf":
         (coco.Coco, dataset.pre_process_coco_resnet34, coco.PostProcessCocoTf(),
-         {"image_size": [1200, 1200, 3],"use_label_map": True}),
+         {"image_size": [1200, 1200, 3],"use_label_map": False}),
 }
 
 # pre-defined command line options so simplify things. They are used as defaults and can be
@@ -504,6 +504,7 @@ def main():
         settings.multi_stream_samples_per_query = args.samples_per_query
     if args.max_latency:
         settings.server_target_latency_ns = int(args.max_latency * NANO_SEC)
+        settings.multi_stream_target_latency_ns = int(args.max_latency * NANO_SEC)
 
     sut = lg.ConstructSUT(issue_queries, flush_queries, process_latencies)
     qsl = lg.ConstructQSL(count, min(count, 500), ds.load_query_samples, ds.unload_query_samples)

--- a/v0.5/classification_and_detection/tools/accuracy-coco.py
+++ b/v0.5/classification_and_detection/tools/accuracy-coco.py
@@ -45,6 +45,7 @@ def main():
     detections = []
     image_ids = set()
     seen = set()
+    no_results = 0
     image_map = cocoGt.dataset["images"]
 
     for j in results:
@@ -59,9 +60,22 @@ def main():
         # id, box[0], box[1], box[2], box[3], score, detection_class
         # note that id is a index into instances_val2017.json, not the actual image_id
         data = np.frombuffer(bytes.fromhex(j['data']), np.float32)
+        if len(data) < 7:
+            # handle images that had no results
+            image = image_map[idx]
+            # by adding the id to image_ids we make pycoco aware of the no-result image
+            image_ids.add(image["id"])
+            no_results += 1
+            if args.verbose:
+                print("no results: {}, idx={}".format(image["coco_url"], idx))
+            continue
+
         for i in range(0, len(data), 7):
             image_idx, ymin, xmin, ymax, xmax, score, label = data[i:i + 7]
             image = image_map[idx]
+            image_idx = int(image_idx)
+            if image_idx != idx:
+                print("ERROR: loadgen({}) and payload({}) disagree on image_idx".format(idx, image_idx))
             image_id = image["id"]
             height, width = image["height"], image["width"]
             ymin *= height
@@ -93,7 +107,10 @@ def main():
 
     print("mAP={:.3f}%".format(100. * cocoEval.stats[0]))
     if args.verbose:
-        print("found and ignored {} dupes".format(len(results) - len(seen)))
+        print("found {} results".format(len(results)))
+        print("found {} images".format(len(image_ids)))
+        print("found {} images with no results".format(no_results))
+        print("ignored {} dupes".format(len(results) - len(seen)))
 
 
 if __name__ == "__main__":

--- a/v0.5/classification_and_detection/tools/ci-run.sh
+++ b/v0.5/classification_and_detection/tools/ci-run.sh
@@ -1,60 +1,78 @@
 #!/bin/bash
 
+# where to find stuff
+export DATA_ROOT=`pwd`/data
+export MODEL_DIR=`pwd`/models
 
-# CI end to end test for all models
-
-if [ "x$DATA_ROOT" == "x" ]; then
-    echo "DATA_ROOT not set" && exit 1
-fi
-if [ "x$MODEL_DIR" == "x" ]; then
-    echo "MODEL_DIR not set" && exit 1
-fi
+export DATA_ROOT=/data
+export MODEL_DIR=$HOME/resnet_for_mlperf
 
 
-# gloal options for all runs
-gopt="--max-latency 0.05,0.1"
-
-# quick run (you'd set this from the ci system)
-# gopt="$gopt --queries-single 1000 --queries-offline 1000 --queries-multi 1000 --time 30 --count 500"
-
+# options for official runs
+gopt="--max-batchsize 32 --samples-per-query 2 --threads 2"
 gopt="$gopt $@"
 
+result=output/results.csv
+
 function one_run {
-    ./run_local.sh $* --scenario SingleStream 
-    ./run_local.sh $* --scenario SingleStream --accuracy
-    ./run_local.sh $* --scenario MultiStream
-    ./run_local.sh $* --scenario Server
-    ./run_local.sh $* --scenario Offline
+    # args: mode framework device model ...
+    scenario=$1; shift
+    model=$3
+    system_desc=$1-$2
+    case $model in
+    "mobilenet")
+      official_model="mobilenet"
+      acc_cmd="tools/accuracy-imagenet.py --imagenet-val-file $DATA_ROOT/imagenet2012/val_map.txt";;
+    "resnet50")
+      official_model="resnet"
+      acc_cmd="tools/accuracy-imagenet.py --imagenet-val-file $DATA_ROOT/imagenet2012/val_map.txt";;
+    "ssd-mobilenet")
+      official_model="ssd-small"
+      acc_cmd="tools/accuracy-coco.py --coco-dir $DATA_ROOT/coco";;
+    "ssd-resnet34")
+      official_model="ssd-large"
+      acc_cmd="tools/accuracy-coco.py --use-inv-map --coco-dir $DATA_ROOT/coco";;
+    "gnmt")
+      official_model="gnmt";;
+    esac
+    echo "====== $official_model/$scenario ====="
+    output_dir=output/$system_desc/$official_model/$scenario
+
+    # accuracy run
+    ./run_local.sh $@ --scenario $scenario --accuracy --output $output_dir/accuracy
+    python $acc_cmd --verbose --mlperf-accuracy-file $output_dir/accuracy/mlperf_log_accuracy.json \
+           >  $output_dir/accuracy/accuracy.txt
+    cat $output_dir/accuracy/accuracy.txt
+
+    # performance run
+    ./run_local.sh $@ --scenario $scenario --output $output_dir/performance
+    
+    # summary to csv
+    python tools/lglog2csv.py --input $output_dir/performance/mlperf_log_summary.txt --runtime "$1-$2" \
+      --machine $HOSTNAME --model $3 --name $1-$2-py >> $result
 }
 
+function one_model {
+    # args: framework device model ...
+    one_run SingleStream $@
+    one_run MultiStream $@
+    one_run Server $@
+    one_run Offline $@
+}
+
+
+mkdir output
+echo "build,date,machine,runtime,model,mode,qps,mean,latency_90,latency_99" > $result
+
+# TODO: add gnmt
+
+# using imagenet
 export DATA_DIR=$DATA_ROOT/imagenet2012
+#one_model onnxruntime cpu mobilenet $gopt
+#one_model tf gpu resnet50 $gopt
 
-#
-# resnet50
-#
-one_run tf gpu resnet50 --qps 200 $gopt
-one_run tf cpu resnet50 --qps 20 $gopt
-one_run onnxruntime cpu resnet50 --qps 20 $gopt
-
-#
-# mobilenet
-#
-one_run tf gpu mobilenet --qps 250 $gopt
-one_run tf cpu mobilenet --qps 20 $gopt
-one_run onnxruntime cpu mobilenet --qps 20 $gopt
-
+# using coco
 export DATA_DIR=$DATA_ROOT/coco
-
-#
-# ssd-mobilenet
-#
-one_run tf gpu ssd-mobilenet --qps 50 $gopt
-one_run tf cpu ssd-mobilenet --qps 50 $gopt
-one_run onnxruntime cpu ssd-mobilenet --qps 50 $gopt
-
-one_run tf gpu ssd-resnet34 --qps 50 $gopt
-one_run tf cpu ssd-resnet34 --qps 50 $gopt
-one_run onnxruntime cpu ssd-resnet34-tf --qps 1 $gopt
-#one_run onnxruntime cpu ssd-resnet34 --qps 1 $gopt
-#one_run pytorch cpu ssd-resnet34 --qps 1 $gopt
-#one_run pytorch gpu ssd-resnet34 --qps 1 $gopt
+#one_model tf gpu ssd-mobilenet $gopt
+one_model tf gpu ssd-resnet34 $gopt
+#one_model onnxruntime cpu ssd-resnet34 $gopt


### PR DESCRIPTION
During coco mAP processing we ignored queries with empty results - https://github.com/mlperf/inference/issues/329.

This PR also fixed that ```--count``` used 1 image more than requested - https://github.com/mlperf/inference/issues/324
