### PR TITLE
loadgen: Various no-op cleanups.

### DIFF
--- a/loadgen/loadgen.cc
+++ b/loadgen/loadgen.cc
@@ -827,11 +827,6 @@ struct PerformanceSummary {
   PercentileEntry latency_percentiles[6] = {{.50}, {.90}, {.95},
                                             {.97}, {.99}, {.999}};
 
-  PerformanceSummary(const std::string& sut_name_arg,
-                     const TestSettingsInternal& settings_arg,
-                     const PerformanceResult& pr_arg)
-      : sut_name(sut_name_arg), settings(settings_arg), pr(pr_arg){};
-
   void ProcessLatencies();
 
   bool MinDurationMet(std::string* recommendation);
@@ -1595,7 +1590,8 @@ void StartTest(SystemUnderTest* sut, QuerySampleLibrary* qsl,
                              audit_scenario);
   }
 
-  loadgen::TestSettingsInternal sanitized_settings(test_settings, qsl);
+  loadgen::TestSettingsInternal sanitized_settings(
+      test_settings, qsl->PerformanceSampleCount());
   sanitized_settings.LogAllSettings();
 
   auto run_funcs = loadgen::RunFunctions::Get(sanitized_settings.scenario);

--- a/loadgen/test_settings.h
+++ b/loadgen/test_settings.h
@@ -250,7 +250,7 @@ struct TestSettings {
   double accuracy_log_probability = 0.0;
 
   /// \brief Load mlperf parameter config from file.
-  int FromConfig(const std::string &config_file, const std::string &model,
+  int FromConfig(const std::string &path, const std::string &model,
                  const std::string &scenario);
   /**@}*/
 

--- a/loadgen/test_settings_internal.h
+++ b/loadgen/test_settings_internal.h
@@ -21,8 +21,6 @@ limitations under the License.
 #include <string>
 
 #include "logging.h"
-#include "query_sample.h"
-#include "query_sample_library.h"
 #include "test_settings.h"
 
 namespace mlperf {
@@ -44,7 +42,7 @@ std::string ToString(TestMode mode);
 /// the concept of target_duration used to pre-generate queries.
 struct TestSettingsInternal {
   explicit TestSettingsInternal(const TestSettings &requested_settings,
-                                QuerySampleLibrary *qsl);
+                                size_t qsl_performance_sample_count);
   void LogEffectiveSettings() const;
   void LogAllSettings() const;
   void LogSummary(AsyncSummary &summary) const;

--- a/loadgen/tests/loadgen_test.h
+++ b/loadgen/tests/loadgen_test.h
@@ -13,6 +13,9 @@ limitations under the License.
 /// \file
 /// \brief A minimal test framework.
 
+#ifndef MLPERF_LOADGEN_TESTS_LOADGEN_TEST_H_
+#define MLPERF_LOADGEN_TESTS_LOADGEN_TEST_H_
+
 #include <algorithm>
 #include <exception>
 #include <functional>
@@ -192,3 +195,5 @@ class Test {
 // The testing namespace exists for documentation purposes.
 // Export the testing namespace for all files that define tests.
 using namespace testing;
+
+#endif  // MLPERF_LOADGEN_TESTS_LOADGEN_TEST_H_


### PR DESCRIPTION
* Remove TestSettingsInternal dependency on QSL.
* Make FromConfig argument naming consistent.
* Delete PerformanceSummary constructor that was causing
  moves of PerformanceResults to unintentionally copy.
* Fix error lambdas that were capturing info but not
  reporting them.
* Add ifndef guards to loadgen_test.h.
* Replace C-style casts with C++ static_cast.