### PR TITLE
On MacOS/LLVM thread_ids are not auto-convertible to uint64_t

### DIFF
--- a/loadgen/logging.cc
+++ b/loadgen/logging.cc
@@ -49,6 +49,8 @@ limitations under the License.
 #define MLPERF_GET_TID() syscall(SYS_gettid)
 #elif defined(_WIN32) || defined(WIN32) || defined(_WIN64) || defined(WIN64)
 #define MLPERF_GET_TID() GetCurrentThreadId()
+#elif defined(__APPLE__)
+#define MLPERF_GET_TID() std::hash<std::thread::id>{}(std::this_thread::get_id())
 #else
 // TODO: std::this_thread::id is a class but MLPERF_GET_TID() assigned to
 // uint64_t


### PR DESCRIPTION
On MacOS/LLVM thread_ids are not auto-convertible to uint64_t ,
so we have to convert them manually.

This solution follows the most popular reply from
https://stackoverflow.com/questions/7432100/how-to-get-integer-thread-id-in-c11