### PR TITLE
Split on any whitespace in val_map.txt, not just tab

### DIFF
--- a/v0.5/classification_and_detection/tools/accuracy-imagenet.py
+++ b/v0.5/classification_and_detection/tools/accuracy-imagenet.py
@@ -37,7 +37,7 @@ def main():
     imagenet = []
     with open(args.imagenet_val_file, "r") as f:
         for line in f:
-            cols = line.strip().split("\t")
+            cols = line.strip().split()
             imagenet.append((cols[0], int(cols[1])))
 
     with open(args.mlperf_accuracy_file, "r") as f:


### PR DESCRIPTION
Presently, the `accuracy-imagenet.py` script splits lines in `val_map.txt` on tabs (`\t`). However, there may well be any whitespace between the file name and correct label. For example, `val_map.txt` obtained from Caffe archives according to the [official README](https://github.com/mlperf/inference/tree/master/v0.5/classification_and_detection#imagenet-2012-validation-dataset) uses a single space.

Using `.split()` without any arguments [splits on any whitespace](https://stackoverflow.com/questions/8113782/split-string-on-whitespace-in-python).