### PR TITLE
 Offline scenario PerformanceOnly mode should generate 1 instead of 2 queries

### DIFF
--- a/loadgen/loadgen.cc
+++ b/loadgen/loadgen.cc
@@ -359,10 +359,11 @@ std::vector<QueryMetadata> GenerateQueries(
 
   std::vector<QuerySampleIndex> samples(samples_per_query);
   std::chrono::nanoseconds timestamp(0);
+  std::chrono::nanoseconds prev_timestamp(0);
   // Choose a single sample to repeat when in performance_issue_same mode
   QuerySampleIndex same_sample = settings.performance_issue_same_index;
 
-  while (timestamp <= gen_duration || queries.size() < min_queries) {
+  while (prev_timestamp <= gen_duration || queries.size() < min_queries) {
     if (kIsMultiStream) {
       QuerySampleIndex sample_i = settings.performance_issue_unique
                                    ? sample_distribution_unique(sample_rng)
@@ -408,6 +409,7 @@ std::vector<QueryMetadata> GenerateQueries(
       }
     }
     queries.emplace_back(samples, timestamp, response_delegate, sequence_gen);
+    prev_timestamp = timestamp;
     timestamp += schedule_distribution(schedule_rng);
   }
 

--- a/loadgen/loadgen.cc
+++ b/loadgen/loadgen.cc
@@ -330,7 +330,7 @@ std::vector<QueryMetadata> GenerateQueries(
   // We should not exit early in accuracy mode.
   if (mode == TestMode::AccuracyOnly || settings.performance_issue_unique ||
       settings.performance_issue_same) {
-    gen_duration = std::chrono::microseconds(-1);
+    gen_duration = std::chrono::microseconds(0);
     // Integer truncation here is intentional.
     // For MultiStream, loaded samples is properly padded.
     // For Offline, we create a 'remainder' query at the end of this function.
@@ -365,7 +365,7 @@ std::vector<QueryMetadata> GenerateQueries(
   // Choose a single sample to repeat when in performance_issue_same mode
   QuerySampleIndex same_sample = settings.performance_issue_same_index;
 
-  while (prev_timestamp <= gen_duration || queries.size() < min_queries) {
+  while (prev_timestamp < gen_duration || queries.size() < min_queries) {
     if (kIsMultiStream) {
       QuerySampleIndex sample_i = settings.performance_issue_unique
                                       ? sample_distribution_unique(sample_rng)


### PR DESCRIPTION
In #414, we introduced `prev_timestamp` to solve the issue that server scenario never met min_duration. However, it caused a crash for multi_stream accuracy mode, and #420 fixed it by setting `gen_duration` to -1. However (again), there is still a bug that in offline scenario - performance mode, LoadGen generates 2 queries instead of 1 because gen_duration is 0. 

This PR applies the correct fix for the two issues caused by #414. We should make sure that whenever `gen_duration` is 0, LoadGen only generates 1 query. This fix won't affect server mode because the last query will be guaranteed to be just above the min_duration.