### PR TITLE
there was a dot missing when parsing items from config file

### DIFF
--- a/loadgen/test_settings_internal.cc
+++ b/loadgen/test_settings_internal.cc
@@ -334,7 +334,7 @@ int TestSettings::FromConfig(const std::string &path, const std::string &model,
     std::map<std::string, std::string>::iterator it;
     std::string found;
     // lookup exact key first
-    it = kv.find(model + scenario + "." + key);
+    it = kv.find(model + "." + scenario + "." + key);
     if (it != kv.end()) {
       found = it->second;
     } else {


### PR DESCRIPTION
fix for https://github.com/mlperf/inference/issues/464
