### PR TITLE
add performance_sample_count_override and seeds to config

### DIFF
--- a/loadgen/test_settings_internal.cc
+++ b/loadgen/test_settings_internal.cc
@@ -343,13 +343,22 @@ int TestSettings::FromConfig(const std::string &path, const std::string &model,
       if (it != kv.end()) {
         found = it->second;
       } else {
-        return false;
+        it = kv.find(model + ".*." + key);
+        if (it != kv.end()) {
+          found = it->second;
+        } else {
+          it = kv.find("*.*." + key);
+          if (it != kv.end()) {
+            found = it->second;
+          } else {
+            return false;
+          }
+        }
       }
     }
     // if we get here, found will be set
     if (val_l) {
-      *val_l =
-          strtoul(found.c_str(), nullptr, 0) * static_cast<int>(multiplier);
+      *val_l = strtoull(found.c_str(), nullptr, 0) * static_cast<uint64_t>(multiplier);
     }
     if (val_d) *val_d = strtod(found.c_str(), nullptr) * multiplier;
     return true;

--- a/v0.5/mlperf.conf
+++ b/v0.5/mlperf.conf
@@ -7,7 +7,7 @@
 mobilenet.*.performance_sample_count_override = 1024
 resnet50.*.performance_sample_count_override = 1024
 ssd-mobilenet.*.performance_sample_count_override = 256
-ssd-resnet34.*performance_sample_count_override = 64
+ssd-resnet34.*.performance_sample_count_override = 64
 gnmt.*.performance_sample_count_override = 3903900
 
 # set seeds

--- a/v0.5/mlperf.conf
+++ b/v0.5/mlperf.conf
@@ -12,7 +12,7 @@ gnmt.*.performance_sample_count_override = 3903900
 
 # set seeds
 *.*.qsl_rng_seed = 3133965575612453542
-*.*.sample_index_rng_seed = 41592772053807303
+*.*.sample_index_rng_seed = 665484352860916858
 *.*.schedule_rng_seed = 3622009729038561421
 
 *.SingleStream.target_latency = 10

--- a/v0.5/mlperf.conf
+++ b/v0.5/mlperf.conf
@@ -3,6 +3,18 @@
 # Model maybe '*' as wildcard. In that case the value applies to all models.
 # All times are in milli seconds
 
+# set performance_sample_count for each model
+mobilenet.*.performance_sample_count_override = 1024
+resnet50.*.performance_sample_count_override = 1024
+ssd-mobilenet.*.performance_sample_count_override = 256
+ssd-resnet34.*performance_sample_count_override = 64
+gnmt.*.performance_sample_count_override = 3903900
+
+# set seeds
+*.*.qsl_rng_seed = 3133965575612453542
+*.*.sample_index_rng_seed = 41592772053807303
+*.*.schedule_rng_seed = 3622009729038561421
+
 *.SingleStream.target_latency = 10
 *.SingleStream.target_latency_percentile = 90
 *.SingleStream.min_duration = 60000


### PR DESCRIPTION
deals with https://github.com/mlperf/inference/issues/488

- allow wildcard to for scenario
- add seeds to mlperf.conf
- add performance_sample_count_override to mlperf.conf
- use strtoll() instead of strtol()

@psyhtest , @tjablin 