### PR TITLE
Include <string> to build loadgen on Windows with MSVC

### DIFF
--- a/loadgen/query_sample_library.h
+++ b/loadgen/query_sample_library.h
@@ -18,6 +18,7 @@ limitations under the License.
 
 #include <memory>
 #include <vector>
+#include <string>
 
 #include "query_sample.h"
 


### PR DESCRIPTION
Without this, loadgen cannot be built on Windows due to the following failure:

```
C:\Program Files (x86)\Microsoft Visual Studio\2019\Professional\VC\Tools\MSVC\14.23.28105\bin\HostX86\x64\cl.exe /c /nologo /Ox /W3 /GL /DNDEBUG /MD -DMAJOR_VERSION=0 -DMINOR_VERSION=5 -I. -I../third_party/pybind/include -ID:\MLPerf\mlperf-python3-tensorflow-1.14\Include\site\python3.7 "-Ic:\program files (x86)\microsoft visual studio\shared\python37_64\include" "-Ic:\program files (x86)\microsoft visual studio\shared\python37_64\include" "-IC:\Program Files (x86)\Microsoft Visual Studio\2019\Professional\VC\Tools\MSVC\14.23.28105\ATLMFC\include" "-IC:\Program Files (x86)\Microsoft Visual Studio\2019\Professional\VC\Tools\MSVC\14.23.28105\include" "-IC:\Program Files (x86)\Windows Kits\10\include\10.0.18362.0\ucrt" "-IC:\Program Files (x86)\Windows Kits\10\include\10.0.18362.0\shared" "-IC:\Program Files (x86)\Windows Kits\10\include\10.0.18362.0\um" "-IC:\Program Files (x86)\Windows Kits\10\include\10.0.18362.0\winrt" "-IC:\Program Files (x86)\Windows Kits\10\include\10.0.18362.0\cppwinrt" /EHsc /Tpbindings/python_api.cc /Fobuild\temp.win-amd64-3.7\Release\bindings/python_api.obj
python_api.cc
D:\MLPerf\inference\loadgen\bindings\../query_sample_library.h(36): error C2039: 'string': is not a member of 'std'
C:\Program Files (x86)\Microsoft Visual Studio\2019\Professional\VC\Tools\MSVC\14.23.28105\include\vector(20): note: see declaration of 'std'
D:\MLPerf\inference\loadgen\bindings\../query_sample_library.h(36): error C4430: missing type specifier - int assumed. Note: C++ does not support default-int
D:\MLPerf\inference\loadgen\bindings\../query_sample_library.h(36): error C2143: syntax error: missing ';' before '&'
D:\MLPerf\inference\loadgen\bindings\../query_sample_library.h(36): error C2433: 'mlperf::QuerySampleLibrary::string': 'virtual' not permitted on data declarations
D:\MLPerf\inference\loadgen\bindings\../query_sample_library.h(36): error C2238: unexpected token(s) preceding ';'
bindings/python_api.cc(94): error C3668: 'mlperf::`anonymous-namespace'::QuerySampleLibraryTrampoline::Name': method with override specifier 'override' did not override any base class methods
error: command 'C:\\Program Files (x86)\\Microsoft Visual Studio\\2019\\Professional\\VC\\Tools\\MSVC\\14.23.28105\\bin\\HostX86\\x64\\cl.exe' failed with exit status 2
```

With this change, I can use MLPerf on Windows