### PR TITLE
Support ONNX runtime profiling

### DIFF
--- a/v0.7/language/bert/.gitignore
+++ b/v0.7/language/bert/.gitignore
@@ -1,2 +1,3 @@
 build/
 eval_features.pickle
+onnxruntime_profile__*.json

--- a/v0.7/language/bert/.gitignore
+++ b/v0.7/language/bert/.gitignore
@@ -1,1 +1,2 @@
 build/
+eval_features.pickle

--- a/v0.7/language/bert/Makefile
+++ b/v0.7/language/bert/Makefile
@@ -169,3 +169,4 @@ evaluate:
 clean:
 	@rm -rf ${BUILD_DIR}
 	@rm -f  ${FEATURE_CACHE}
+	@rm -f  onnxruntime_profile__*.json

--- a/v0.7/language/bert/Makefile
+++ b/v0.7/language/bert/Makefile
@@ -28,6 +28,7 @@ DATA_DIR := $(BUILD_DIR)/data
 BERT_DIR := $(DATA_DIR)/bert_tf_v1_1_large_fp32_384_v2
 RESULT_DIR := $(BUILD_DIR)/result
 MLPERF_CONF := $(BUILD_DIR)/mlperf.conf
+FEATURE_CACHE := eval_features.pickle
 
 # Handle different nvidia-docker version
 ifneq ($(wildcard /usr/bin/nvidia-docker),)
@@ -166,4 +167,5 @@ evaluate:
 
 .PHONY: clean
 clean:
-	@rm -rf build
+	@rm -rf ${BUILD_DIR}
+	@rm -f  ${FEATURE_CACHE}

--- a/v0.7/language/bert/onnxruntime_SUT.py
+++ b/v0.7/language/bert/onnxruntime_SUT.py
@@ -27,34 +27,39 @@ from transformers import BertConfig, BertForQuestionAnswering
 from squad_QSL import get_squad_QSL
 
 class BERT_ONNXRuntime_SUT():
-    def __init__(self, quantized):
+    def __init__(self, args):
+        self.profile = args.profile
+        self.options = onnxruntime.SessionOptions()
+        self.options.enable_profiling = args.profile
+
         print("Loading ONNX model...")
-        self.quantized = quantized
-        if not quantized:
-            model_path = "build/data/bert_tf_v1_1_large_fp32_384_v2/model.onnx"
-        else:
+        self.quantized = args.quantized
+        if self.quantized:
             model_path = "build/data/bert_tf_v1_1_large_fp32_384_v2/bert_large_v1_1_fake_quant.onnx"
-        self.sess = onnxruntime.InferenceSession(model_path)
+        else:
+            model_path = "build/data/bert_tf_v1_1_large_fp32_384_v2/model.onnx"
+        self.sess = onnxruntime.InferenceSession(model_path, self.options)
 
         print("Constructing SUT...")
         self.sut = lg.ConstructSUT(self.issue_queries, self.flush_queries, self.process_latencies)
-        self.qsl = get_squad_QSL()
         print("Finished constructing SUT.")
+
+        self.qsl = get_squad_QSL()
 
     def issue_queries(self, query_samples):
         for i in range(len(query_samples)):
             eval_features = self.qsl.get_features(query_samples[i].index)
-            if not self.quantized:
-                fd = {
-                    "input_ids": np.array(eval_features.input_ids).astype(np.int64)[np.newaxis, :],
-                    "input_mask": np.array(eval_features.input_mask).astype(np.int64)[np.newaxis, :],
-                    "segment_ids": np.array(eval_features.segment_ids).astype(np.int64)[np.newaxis, :]
-                }
-            else:
+            if self.quantized:
                 fd = {
                     "input_ids": np.array(eval_features.input_ids).astype(np.int64)[np.newaxis, :],
                     "attention_mask": np.array(eval_features.input_mask).astype(np.int64)[np.newaxis, :],
                     "token_type_ids": np.array(eval_features.segment_ids).astype(np.int64)[np.newaxis, :]
+                }
+            else:
+                fd = {
+                    "input_ids": np.array(eval_features.input_ids).astype(np.int64)[np.newaxis, :],
+                    "input_mask": np.array(eval_features.input_mask).astype(np.int64)[np.newaxis, :],
+                    "segment_ids": np.array(eval_features.segment_ids).astype(np.int64)[np.newaxis, :]
                 }
             scores = self.sess.run([o.name for o in self.sess.get_outputs()], fd)
             output = np.stack(scores, axis=-1)[0]
@@ -71,8 +76,9 @@ class BERT_ONNXRuntime_SUT():
         pass
 
     def __del__(self):
-        lg.DestroySUT(self.sut)
+        if self.profile:
+            print("ONNX runtime profile dumped to: '{}'".format(self.sess.end_profiling()))
         print("Finished destroying SUT.")
 
-def get_onnxruntime_sut(quantized=False):
-    return BERT_ONNXRuntime_SUT(quantized)
+def get_onnxruntime_sut(args):
+    return BERT_ONNXRuntime_SUT(args)

--- a/v0.7/language/bert/pytorch_SUT.py
+++ b/v0.7/language/bert/pytorch_SUT.py
@@ -53,8 +53,9 @@ class BERT_PyTorch_SUT():
 
         print("Constructing SUT...")
         self.sut = lg.ConstructSUT(self.issue_queries, self.flush_queries, self.process_latencies)
-        self.qsl = get_squad_QSL()
         print("Finished constructing SUT.")
+
+        self.qsl = get_squad_QSL()
 
     def issue_queries(self, query_samples):
         with torch.no_grad():
@@ -77,7 +78,6 @@ class BERT_PyTorch_SUT():
         pass
 
     def __del__(self):
-        lg.DestroySUT(self.sut)
         print("Finished destroying SUT.")
 
 def get_pytorch_sut():

--- a/v0.7/language/bert/squad_QSL.py
+++ b/v0.7/language/bert/squad_QSL.py
@@ -84,7 +84,6 @@ class SQuAD_v1_QSL():
         return self.eval_features[sample_id]
 
     def __del__(self):
-        lg.DestroyQSL(self.qsl)
         print("Finished destroying QSL.")
 
 def get_squad_QSL():

--- a/v0.7/language/bert/squad_QSL.py
+++ b/v0.7/language/bert/squad_QSL.py
@@ -24,35 +24,50 @@ from utils.create_squad_data import read_squad_examples, convert_examples_to_fea
 
 import mlperf_loadgen as lg
 
+# To support feature cache.
+import pickle
+
 max_seq_length = 384
 max_query_length = 64
 doc_stride = 128
 
 class SQuAD_v1_QSL():
-    def __init__(self, perf_count=None):
-        print("Creating tokenizer...")
-        tokenizer = BertTokenizer("build/data/bert_tf_v1_1_large_fp32_384_v2/vocab.txt")
-
-        print("Reading examples...")
-        eval_examples = read_squad_examples(input_file="build/data/dev-v1.1.json",
-            is_training=False, version_2_with_negative=False)
-
-        print("Converting examples to features...")
-        eval_features = []
-        def append_feature(feature):
-            eval_features.append(feature)
-
-        convert_examples_to_features(
-            examples=eval_examples,
-            tokenizer=tokenizer,
-            max_seq_length=max_seq_length,
-            doc_stride=doc_stride,
-            max_query_length=max_query_length,
-            is_training=False,
-            output_fn=append_feature,
-            verbose_logging=False)
-
+    def __init__(self, perf_count=None, cache_path='eval_features.pickle'):
         print("Constructing QSL...")
+        eval_features = []
+        # Load features if cached, convert from examples otherwise.
+        if os.path.exists(cache_path):
+            print("Loading cached features from '%s'..." % cache_path)
+            with open(cache_path, 'rb') as cache_file:
+                eval_features = pickle.load(cache_file)
+        else:
+            print("No cached features at '%s'... converting from examples..." % cache_path)
+
+            print("Creating tokenizer...")
+            tokenizer = BertTokenizer("build/data/bert_tf_v1_1_large_fp32_384_v2/vocab.txt")
+
+            print("Reading examples...")
+            eval_examples = read_squad_examples(input_file="build/data/dev-v1.1.json",
+                is_training=False, version_2_with_negative=False)
+
+            print("Converting examples to features...")
+            def append_feature(feature):
+                eval_features.append(feature)
+
+            convert_examples_to_features(
+                examples=eval_examples,
+                tokenizer=tokenizer,
+                max_seq_length=max_seq_length,
+                doc_stride=doc_stride,
+                max_query_length=max_query_length,
+                is_training=False,
+                output_fn=append_feature,
+                verbose_logging=False)
+
+            print("Caching features at '%s'..." % cache_path)
+            with open(cache_path, 'wb') as cache_file:
+                pickle.dump(eval_features, cache_file)
+
         self.eval_features = eval_features
         self.count = len(self.eval_features)
         self.perf_count = perf_count if perf_count is not None else self.count

--- a/v0.7/language/bert/squad_eval.py
+++ b/v0.7/language/bert/squad_eval.py
@@ -329,8 +329,8 @@ def main():
     parser = argparse.ArgumentParser()
     parser.add_argument("--vocab_file", default="build/data/bert_tf_v1_1_large_fp32_384_v2/vocab.txt", help="Path to vocab.txt")
     parser.add_argument("--val_data", default="build/data/dev-v1.1.json", help="Path to validation data")
-    parser.add_argument("--log_file", default="build/logs/mlperf_log_accuracy.json", help="Path to loadge accuracy log")
-    parser.add_argument("--out_file", default="build/result/predictions.json", help="Path to output prediction file")
+    parser.add_argument("--log_file", default="build/logs/mlperf_log_accuracy.json", help="Path to LoadGen accuracy log")
+    parser.add_argument("--out_file", default="build/result/predictions.json", help="Path to output predictions file")
     parser.add_argument("--features_cache_file", default="eval_features.pickle", help="Path to features' cache file")
     parser.add_argument("--output_transposed", action="store_true", help="Transpose the output")
     args = parser.parse_args()
@@ -371,10 +371,10 @@ def main():
         with open(cache_path, 'wb') as cache_file:
             pickle.dump(eval_features, cache_file)
 
-    print("Loading loadgen logs...")
+    print("Loading LoadGen logs...")
     results = load_loadgen_log(args.log_file, eval_features, args.output_transposed)
 
-    print("Post-processing predicions...")
+    print("Post-processing predictions...")
     write_predictions(eval_examples, eval_features, results, 20, 30, True, args.out_file)
 
     print("Evaluating predictions...")

--- a/v0.7/language/bert/squad_eval.py
+++ b/v0.7/language/bert/squad_eval.py
@@ -36,6 +36,9 @@ import tokenization
 from transformers import BertConfig, BertTokenizer, BertForQuestionAnswering
 from utils.create_squad_data import read_squad_examples, convert_examples_to_features
 
+# To support feature cache.
+import pickle
+
 max_seq_length = 384
 max_query_length = 64
 doc_stride = 128
@@ -335,6 +338,10 @@ def main():
     parser.add_argument("--output_transposed", action="store_true", help="Transpose the output")
     args = parser.parse_args()
 
+    print("Reading examples...")
+    eval_examples = read_squad_examples(input_file=args.val_data,
+        is_training=False, version_2_with_negative=False)
+
     eval_features = []
     # Load features if cached, convert from examples otherwise.
     cache_path = args.features_cache_file
@@ -347,11 +354,6 @@ def main():
 
         print("Creating tokenizer...")
         tokenizer = BertTokenizer(args.vocab_file)
-
-        print("Reading examples...")
-        eval_examples = read_squad_examples(
-            input_file=args.val_data, is_training=False,
-            version_2_with_negative=False)
 
         print("Converting examples to features...")
         def append_feature(feature):

--- a/v0.7/language/bert/squad_eval.py
+++ b/v0.7/language/bert/squad_eval.py
@@ -331,31 +331,45 @@ def main():
     parser.add_argument("--val_data", default="build/data/dev-v1.1.json", help="Path to validation data")
     parser.add_argument("--log_file", default="build/logs/mlperf_log_accuracy.json", help="Path to loadge accuracy log")
     parser.add_argument("--out_file", default="build/result/predictions.json", help="Path to output prediction file")
+    parser.add_argument("--features_cache_file", default="eval_features.pickle", help="Path to features' cache file")
     parser.add_argument("--output_transposed", action="store_true", help="Transpose the output")
     args = parser.parse_args()
 
-    print("Creating tokenizer...")
-    tokenizer = BertTokenizer(args.vocab_file)
-
-    print("Reading examples...")
-    eval_examples = read_squad_examples(
-        input_file=args.val_data, is_training=False,
-        version_2_with_negative=False)
-
-    print("Converting examples to features...")
     eval_features = []
-    def append_feature(feature):
-        eval_features.append(feature)
+    # Load features if cached, convert from examples otherwise.
+    cache_path = args.features_cache_file
+    if os.path.exists(cache_path):
+        print("Loading cached features from '%s'..." % cache_path)
+        with open(cache_path, 'rb') as cache_file:
+            eval_features = pickle.load(cache_file)
+    else:
+        print("No cached features at '%s'... converting from examples..." % cache_path)
 
-    convert_examples_to_features(
-        examples=eval_examples,
-        tokenizer=tokenizer,
-        max_seq_length=max_seq_length,
-        doc_stride=doc_stride,
-        max_query_length=max_query_length,
-        is_training=False,
-        output_fn=append_feature,
-        verbose_logging=False)
+        print("Creating tokenizer...")
+        tokenizer = BertTokenizer(args.vocab_file)
+
+        print("Reading examples...")
+        eval_examples = read_squad_examples(
+            input_file=args.val_data, is_training=False,
+            version_2_with_negative=False)
+
+        print("Converting examples to features...")
+        def append_feature(feature):
+            eval_features.append(feature)
+
+        convert_examples_to_features(
+            examples=eval_examples,
+            tokenizer=tokenizer,
+            max_seq_length=max_seq_length,
+            doc_stride=doc_stride,
+            max_query_length=max_query_length,
+            is_training=False,
+            output_fn=append_feature,
+            verbose_logging=False)
+
+        print("Caching features at '%s'..." % cache_path)
+        with open(cache_path, 'wb') as cache_file:
+            pickle.dump(eval_features, cache_file)
 
     print("Loading loadgen logs...")
     results = load_loadgen_log(args.log_file, eval_features, args.output_transposed)

--- a/v0.7/language/bert/tf_SUT.py
+++ b/v0.7/language/bert/tf_SUT.py
@@ -46,8 +46,9 @@ class BERT_TF_SUT():
 
         print("Constructing SUT...")
         self.sut = lg.ConstructSUT(self.issue_queries, self.flush_queries, self.process_latencies)
-        self.qsl = get_squad_QSL()
         print("Finished constructing SUT.")
+
+        self.qsl = get_squad_QSL()
 
     def issue_queries(self, query_samples):
         input_ids = np.zeros((len(query_samples), 1, 384), dtype=np.int32)
@@ -81,7 +82,6 @@ class BERT_TF_SUT():
         pass
 
     def __del__(self):
-        lg.DestroySUT(self.sut)
         print("Finished destroying SUT.")
 
     def create_model(self, bert_config, is_training, input_ids, input_mask, segment_ids, use_one_hot_embeddings):


### PR DESCRIPTION
This is a handy feature to check how the ONNX runtime behaves.

Similarly to the `--quantized` flag, the `--profile` flag is not applicable to the other runtimes. When this flag is specified, a run finishes with a message like:
```
Done!
Destroying SUT...
Destroying QSL...
ONNX runtime profile dumped to: 'onnxruntime_profile__2020-05-14_17-11-15.json'
Finished destroying SUT.
Finished destroying QSL.
```

Note that the dumping is supposed to happen in the `BERT_ONNXRuntime_SUT.__del__()` finalizer method. I was puzzled for a while that this method would not be called, but it turned out that this behaviour is [well-known](https://stackoverflow.com/questions/1481488/what-is-the-del-method-how-to-call-it). I had to move `lg.DestroySUT(sut.sut)` and `lg.DestroyQSL(sut.qsl.qsl)` to `run.py` for dumping to happen, and make a similar change in the other SUTs.

Another common change was to:
```
diff --git a/v0.7/language/bert/pytorch_SUT.py b/v0.7/language/bert/pytorch_SUT.py
index 41dd4b2..81df5e1 100644
--- a/v0.7/language/bert/pytorch_SUT.py
+++ b/v0.7/language/bert/pytorch_SUT.py
@@ -53,9 +53,10 @@ class BERT_PyTorch_SUT():
 
         print("Constructing SUT...")
         self.sut = lg.ConstructSUT(self.issue_queries, self.flush_queries, self.process_latencies)
-        self.qsl = get_squad_QSL()
         print("Finished constructing SUT.")
 
+        self.qsl = get_squad_QSL()
+
     def issue_queries(self, query_samples):
         with torch.no_grad():
             for i in range(len(query_samples)):
```
simply to change:
```
Constructing SUT...
Constructing QSL...
Loading cached features from 'eval_features.pickle'...
Finished constructing QSL.
Finished constructing SUT.
```
to:
```
Constructing SUT...
Finished constructing SUT.
Constructing QSL...
Loading cached features from 'eval_features.pickle'...
Finished constructing QSL.
```
which looks more natural.