### PR TITLE
Updating Makefile and Dockerfile for non-GPU run

### DIFF
--- a/v0.7/medical_imaging/3d-unet/Dockerfile
+++ b/v0.7/medical_imaging/3d-unet/Dockerfile
@@ -27,7 +27,7 @@ RUN cd /tmp \
  && rm -rf inference
 
 # Install dependencies
-RUN python3 -m pip install onnx==1.6.0 onnxruntime==1.2.0 numpy==1.18.0 Pillow==7.0.0
+RUN python3 -m pip install onnx onnxruntime numpy==1.18.0 Pillow==7.0.0
 
 # Install nnUnet
 COPY nnUnet /workspace/nnUnet

--- a/v0.7/medical_imaging/3d-unet/Makefile
+++ b/v0.7/medical_imaging/3d-unet/Makefile
@@ -115,7 +115,7 @@ build_docker:
 
 .PHONY: launch_docker
 launch_docker: check_download_data_dir
-	@mkdir -p build/postprocessed_data
+	@mkdir -p $(POSTPROCESSED_DATA_DIR)
 	@echo "Launching docker container..."
 	@$(DOCKER_RUN_CMD) --rm -it -w $(CONTAINER_VOL) -v $(HOST_VOL):$(CONTAINER_VOL) -v ${HOME}:/mnt/${HOME} \
 		-v $(DOWNLOAD_DATA_DIR):/downloaded_data_dir \

--- a/v0.7/medical_imaging/3d-unet/Makefile
+++ b/v0.7/medical_imaging/3d-unet/Makefile
@@ -46,7 +46,7 @@ HAS_GPU := $(shell command -v nvidia-smi 2> /dev/null)
 ifndef $HAS_GPU
     DOCKER_RUN_CMD := docker run
 else
-
+   # Handle different nvidia-docker version
    ifneq ($(wildcard /usr/bin/nvidia-docker),)
 	DOCKER_RUN_CMD := nvidia-docker run
    else

--- a/v0.7/medical_imaging/3d-unet/Makefile
+++ b/v0.7/medical_imaging/3d-unet/Makefile
@@ -1,3 +1,4 @@
+# t
 # Copyright (c) 2020, NVIDIA CORPORATION.  All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -41,11 +42,18 @@ export nnUNet_raw_data_base=$(RAW_DATA_DIR)
 export nnUNet_preprocessed=$(PREPROCESSED_DATA_DIR)
 export RESULTS_FOLDER=$(RESULT_DIR)
 
-# Handle different nvidia-docker version
-ifneq ($(wildcard /usr/bin/nvidia-docker),)
-	DOCKER_RUN_CMD := nvidia-docker run
+HAS_GPU := $(shell command -v nvidia-smi 2> /dev/null)
+
+ifndef $HAS_GPU
+    DOCKER_RUN_CMD := docker run
 else
+
+   ifneq ($(wildcard /usr/bin/nvidia-docker),)
+	DOCKER_RUN_CMD := nvidia-docker run
+   else
 	DOCKER_RUN_CMD := docker run --gpus=all
+   endif
+
 endif
 
 .PHONY: setup
@@ -108,6 +116,7 @@ build_docker:
 
 .PHONY: launch_docker
 launch_docker: check_download_data_dir
+	@mkdir -p build/postprocessed_data
 	@echo "Launching docker container..."
 	@$(DOCKER_RUN_CMD) --rm -it -w $(CONTAINER_VOL) -v $(HOST_VOL):$(CONTAINER_VOL) -v ${HOME}:/mnt/${HOME} \
 		-v $(DOWNLOAD_DATA_DIR):/downloaded_data_dir \

--- a/v0.7/medical_imaging/3d-unet/Makefile
+++ b/v0.7/medical_imaging/3d-unet/Makefile
@@ -1,4 +1,3 @@
-# t
 # Copyright (c) 2020, NVIDIA CORPORATION.  All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
Minor changes to allow Docker and Makefile to run on CPU. Just removing the --gpus if no `nvidia-smi` command found. Also, need to `mkdir` for the output otherwise script crashes the first time.