### PR TITLE
Fix LoadGen Python binding missing symbol error

### DIFF
--- a/loadgen/setup.py
+++ b/loadgen/setup.py
@@ -49,6 +49,7 @@ lib_headers = [
 ]
 
 lib_sources = [
+    "issue_query_controller.cc",
     "loadgen.cc",
     "logging.cc",
     "test_settings_internal.cc",


### PR DESCRIPTION
Fix LoadGen Python binding missing symbol error