### PR TITLE
Fix top-level README description

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-MLPerf Inference is a benchmark suite for measuring how fast systems can train models to a target quality metric. 
+MLPerf Inference is a benchmark suite for measuring how fast systems can run models in a variety of deployment scenarios. 
 
 Please see the [MLPerf Inference benchmark paper](https://arxiv.org/abs/1911.02549) for a detailed description of the benchmarks along with the motivation and guiding principles behind the benchmark suite. If you use any part of this benchmark (e.g., reference implementations, submissions, etc.), please cite the following:
 


### PR DESCRIPTION
This isn't the training repo.