### PR TITLE
Update run_and_time.sh to support docker 19.03 and newer

### DIFF
--- a/vision/classification_and_detection/run_and_time.sh
+++ b/vision/classification_and_detection/run_and_time.sh
@@ -3,8 +3,24 @@
 source run_common.sh
 
 dockercmd=docker
+
+# Get the Docker version
+
+version_major=$(docker version -f '{{.Client.Version}}' | cut -f1 -d.)
+version_minor=$(docker version -f '{{.Client.Version}}' | cut -f2 -d.)
+version_patch=$(docker version -f '{{.Client.Version}}' | cut -f3 -d.)
+
+# Set the appropriate GPU runtime flags based on the Docker version
+
 if [ $device == "gpu" ]; then
+    # Docker is older than 19.03
     runtime="--runtime=nvidia"
+    # Docker is 19.03 or newer
+    if [ $version_major -gt 18 ]; then
+	if [ $version_minor -ge 3 ]; then
+	    runtime="--gpus=all"
+	fi
+    fi
 fi
 
 # copy the config to cwd so the docker contrainer has access


### PR DESCRIPTION
Currently, running run_and_time.sh with docker clients >= 19.03 fails due to the hard coded use of --runtime=nvidia. Since newer docker clients use --gpus instead of --runtime=nvidia (https://github.com/docker/cli/pull/1714) this change checks for the version of docker and selects one or the other.

The change assumes that all gpus will be used.