### PR TITLE
fixing end bracket insertion in create_accuracy_baseline.sh

### DIFF
--- a/compliance/nvidia/TEST01/create_accuracy_baseline.sh
+++ b/compliance/nvidia/TEST01/create_accuracy_baseline.sh
@@ -14,6 +14,6 @@ accuracy_baseline="${accuracy_baseline%.*}"_baseline.json
 cut -d ':' -f 2,3 ${perf_log} | cut -d ',' -f 2- | sort | uniq | grep qsl > ${patterns}
 echo '[' > ${accuracy_baseline}
 grep -f ${patterns} ${accuracy_log} >> ${accuracy_baseline}
-sed -i '$ s/,$/]/g' ${accuracy_baseline}
+echo ']' >> ${accuracy_baseline}
 rm ${patterns}
 echo "Created a baseline accuracy file: ${accuracy_baseline}"

--- a/compliance/nvidia/TEST01/create_accuracy_baseline.sh
+++ b/compliance/nvidia/TEST01/create_accuracy_baseline.sh
@@ -14,6 +14,7 @@ accuracy_baseline="${accuracy_baseline%.*}"_baseline.json
 cut -d ':' -f 2,3 ${perf_log} | cut -d ',' -f 2- | sort | uniq | grep qsl > ${patterns}
 echo '[' > ${accuracy_baseline}
 grep -f ${patterns} ${accuracy_log} >> ${accuracy_baseline}
+sed -i '$ s/,$//g' ${accuracy_baseline}
 echo ']' >> ${accuracy_baseline}
 rm ${patterns}
 echo "Created a baseline accuracy file: ${accuracy_baseline}"


### PR DESCRIPTION
Noticing old code was not working anymore in certain cases. New change is more resilient.