### PR TITLE
Add pybind11 to environment dependencies of RNNT

### DIFF
--- a/speech_recognition/rnnt/environment.yml
+++ b/speech_recognition/rnnt/environment.yml
@@ -100,6 +100,7 @@ dependencies:
     - protobuf==3.11.3
     - ptyprocess==0.6.0
     - py==1.8.1
+    - pybind11==2.4.3
     - pycodestyle==2.5.0
     - pyflakes==2.1.1
     - pygments==2.6.1


### PR DESCRIPTION
I was unable to test RNNT model with the run.sh script since pybind11 was missing in dependencies. Installing it manually also didn't help only after adding it to dependencies test have run successfully.