### PR TITLE
Add EndTest function to loadgen

### DIFF
--- a/loadgen/loadgen.cc
+++ b/loadgen/loadgen.cc
@@ -1362,6 +1362,13 @@ void StartTest(SystemUnderTest* sut, QuerySampleLibrary* qsl,
   GlobalLogger().StopIOThread();
 }
 
+void EndTest() {
+  loadgen::IssueQueryController::GetInstance().EndThreads();
+  GlobalLogger().StopLogging();
+  GlobalLogger().StopTracing();
+  GlobalLogger().StopIOThread();
+}
+
 void QuerySamplesComplete(QuerySampleResponse* responses,
                           size_t response_count) {
   PerfClock::time_point timestamp = PerfClock::now();

--- a/loadgen/loadgen.cc
+++ b/loadgen/loadgen.cc
@@ -1362,7 +1362,7 @@ void StartTest(SystemUnderTest* sut, QuerySampleLibrary* qsl,
   GlobalLogger().StopIOThread();
 }
 
-void EndTest() {
+void AbortTest() {
   loadgen::IssueQueryController::GetInstance().EndThreads();
   GlobalLogger().StopLogging();
   GlobalLogger().StopTracing();

--- a/loadgen/loadgen.h
+++ b/loadgen/loadgen.h
@@ -59,6 +59,12 @@ void StartTest(SystemUnderTest* sut, QuerySampleLibrary* qsl,
                const LogSettings& log_settings);
 
 ///
+/// \brief End the running test.
+/// \details Since StartTest is a blocking function, this function can only
+/// be called in another thread.
+void EndTest();
+
+///
 /// \brief Register a thread for query issuing in Server scenario.
 /// \details If a thread registers itself, the thread(s) is used to call SUT's
 /// IssueQuery(). This function is blocking until the entire test is done. The

--- a/loadgen/loadgen.h
+++ b/loadgen/loadgen.h
@@ -59,10 +59,11 @@ void StartTest(SystemUnderTest* sut, QuerySampleLibrary* qsl,
                const LogSettings& log_settings);
 
 ///
-/// \brief End the running test.
-/// \details Since StartTest is a blocking function, this function can only
-/// be called in another thread.
-void EndTest();
+/// \brief Aborts the running test.
+/// \details This function will stop issueing new samples to the SUT. StartTest
+/// will return after the current inference finishes. Since StartTest is a
+/// blocking function, this function can only be called in another thread.
+void AbortTest();
 
 ///
 /// \brief Register a thread for query issuing in Server scenario.


### PR DESCRIPTION
We need this ability for the Mobile Working group.
In the mobile app, it is desirable to be able to stop the loadgen when users exit/pause the app.
We faces several crashing cases without this feature.